### PR TITLE
Command file no-profile mode processing of individual files

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -223,6 +223,7 @@ public class CommandFactoryImpl implements CommandFactory {
     @Override
     public DroidCommand getNoProfileCommand(final CommandLine cli) throws CommandLineSyntaxException {
         final String[] resources = cli.getOptionValues(CommandLineParam.RUN_NO_PROFILE.toString());
+
         if (resources.length == 0) {
             throw new CommandLineSyntaxException(NO_RESOURCES_SPECIFIED);
         }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommandTest.java
@@ -67,7 +67,7 @@ public class NoProfileRunCommandTest {
             command.execute();
             fail("Expected CommandExecutionException");
         } catch (CommandExecutionException x) {
-            assertEquals("Resources directory not found", x.getMessage());
+            assertEquals("The specified input test1.txt was not found", x.getMessage());
         } finally {
 //            sigFile.delete();
         }

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalConfig.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalConfig.java
@@ -68,7 +68,7 @@ public class DroidGlobalConfig {
     private static final String DEFAULT_DROID_PROPERTIES = "default_droid.properties";
 
     //FIXME: update to latest signature file before release.
-    private static final String DROID_SIGNATURE_FILE = "DROID_SignatureFile_V68.xml";
+    private static final String DROID_SIGNATURE_FILE = "DROID_SignatureFile_V74.xml";
     private static final String CONTAINER_SIGNATURE_FILE = "container-signature-20130501.xml";
     private static final String TEXT_SIGNATURE_FILE = "text-signature-20101101.xml";
     


### PR DESCRIPTION
Introduces the facilitity to all command line  "no-profile" mode to be run against individual files, as well as folders.  There are also a few associated changes to the output log messages and parameter validation as some of the parameters are not erlevant when running against a file as opposed to a folder.  Furthermore, a message is output if the user supplies more than one path (files, folders or a mixture) to the effect that only the first path will be processed (this is what happens currently but no warning is displayed).
