### PR TITLE
Command line interface in no profile mode to process single files as well as folders

### DIFF
--- a/droid-command-line/checkstyle/suppressions.xml
+++ b/droid-command-line/checkstyle/suppressions.xml
@@ -66,7 +66,7 @@
               files=".*Test\.java$"/>
 
     <suppress checks="CyclomaticComplexityCheck|MemberName|ClassDataAbstractionCoupling" files="ResultPrinter.java|NoProfileRunCommand.java"/>
-    
+    <suppress checks="CyclomaticComplexityCheck" files="NoProfileRunCommand.java"/>
     <!--
       Turn off all checks for Generated and Test code. Fixes issues with using
       Eclipse plug-in.

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -216,8 +216,6 @@ public class NoProfileRunCommand implements DroidCommand {
     	
     	// BNO Currently if the user specifies more than one folder/file with the -Nr switch, only the first 
     	// item is processed, but no message is output. Therefore added code to inform the user accordingly.
-    	// N.B. Not fully tested - as in Eclipse the switch command arguments don't seem to get parsed correctly,
-    	//  it doesn't always seem to know where one argument ends and the next one starts!!
     	if (resources.length > 1) {
     		System.out.println(String.format(MULTIPLE_RESOURCES_SPECIFIED, targetDirectoryOrFile));
     	}

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalConfig.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalConfig.java
@@ -73,7 +73,7 @@ public class DroidGlobalConfig {
     private static final String DEFAULT_DROID_PROPERTIES = "default_droid.properties";
 
     //FIXME: update to latest signature file before release.
-    private static final String DROID_SIGNATURE_FILE = "DROID_SignatureFile_V74.xml";
+    private static final String DROID_SIGNATURE_FILE = "DROID_SignatureFile_V69.xml";
     private static final String CONTAINER_SIGNATURE_FILE = "container-signature-20130501.xml";
     private static final String TEXT_SIGNATURE_FILE = "text-signature-20101101.xml";
     

--- a/droid-help/src/main/resources/Web pages/Command line control.html
+++ b/droid-help/src/main/resources/Web pages/Command line control.html
@@ -458,10 +458,10 @@
        of it starting up a database to store intermediate results for reporting.
     </p>
     <h3>
-       -Nr,&nbsp;--no-profile-resource &nbsp; &lt;folder&gt;
+       -Nr,&nbsp;--no-profile-resource &nbsp; &lt;folder or file&gt;
     </h3>
     <p>
-      Identify files in a folder without the use of a profile.  The folder path should
+      Identify either a specific file, or all files in a folder, without the use of a profile.  The file or folder path should
       be bounded by double quotes.  The scan results will be sent to standard output.
       For example:
       <table cellpadding="8" bgcolor="#000000" border="0" cellspacing="0" width="100%">


### PR DESCRIPTION
Introduces the facilitity to all command line "no-profile" mode to be run against individual files, as well as folders. There are also a few associated changes to the output log messages and parameter validation as some of the parameters are not erlevant when running against a file as opposed to a folder. Furthermore, a message is output if the user supplies more than one path (files, folders or a mixture) to the effect that only the first path will be processed (this is what happens currently but no warning is displayed).
