### PR TITLE
Java8 javadoc

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/DroidCommandLine.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/DroidCommandLine.java
@@ -154,8 +154,8 @@ public final class DroidCommandLine {
      * 
      * @param args
      *            the command line arguments
-     * @throws CommandLineException 
-     * @throws CommandExecutionException 
+     * @throws CommandLineException if bad command
+     * @throws CommandExecutionException if cannot execute command
      */
     public static void main(final String[] args) throws CommandLineException {
 
@@ -176,7 +176,7 @@ public final class DroidCommandLine {
     /**
      * 
      * @return a status code 0 success otherwise 1
-     * @throws CommandLineException 
+     * @throws CommandLineException on bad command
      */
     public int processExecution() throws CommandLineException {
         
@@ -228,7 +228,7 @@ public final class DroidCommandLine {
 
     /**
      * 
-     * @param commandFactory 
+     * @param commandFactory the factory
      */
     public void setCommandFactory(CommandFactory commandFactory) {
         this.commandFactory = commandFactory;

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactory.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactory.java
@@ -86,7 +86,7 @@ public interface CommandFactory {
 
     /**
      * @param cli the command line;
-     * @return a new {@link RunProfileCommand}
+     * @return a new {@link DroidCommand}
      * @throws CommandLineSyntaxException if the command line args were invalid
      */
     DroidCommand getProfileCommand(CommandLine cli) throws CommandLineSyntaxException;
@@ -94,7 +94,7 @@ public interface CommandFactory {
 
     /**
      * @param cli the command line;
-     * @return a new {@link RunNoProfileCommand}
+     * @return a new {@link DroidCommand}
      * @throws CommandLineSyntaxException if the command line args were invalid
      */
     DroidCommand getNoProfileCommand(CommandLine cli) throws CommandLineSyntaxException;

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -281,7 +281,7 @@ public class CommandFactoryImpl implements CommandFactory {
     /**
      * {@inheritDoc}
      *
-     * @throws CommandLineSyntaxException
+     * @throws CommandLineSyntaxException on bad syntax in command
      */
     @Override
     public DroidCommand getConfigureDefaultSignatureVersionCommand(final CommandLine cli) throws CommandLineException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/EnumerationAdapter.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/EnumerationAdapter.java
@@ -37,8 +37,7 @@ import java.util.Iterator;
 /**
  * Adapts an enumeration to the Iterator interface.
  * @author rflitcroft
- *
- * @param <T>
+ * @param <T> The type of elements in this enumeration
  */
 public class EnumerationAdapter<T> implements Iterator<T> {
     

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationRequest.java
@@ -65,7 +65,7 @@ public interface IdentificationRequest {
      * calls add up, as reading a byte is the most called method in the
      * entirety of droid - by orders of magnitude.  It makes a real difference
      * to the processing speed to avoid additional call overhead here.
-     * Done only as a result of profiling the software.<p/>
+     * Done only as a result of profiling the software.</p>
      * 
      * @return A net.domesdaybook.reader.ByteReader object,
      */

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationResult.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationResult.java
@@ -87,7 +87,6 @@ public interface IdentificationResult {
     
     /**
      * @return the request identifier
-     * @return
      */
     RequestIdentifier getIdentifier();
 

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFileUtils.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFileUtils.java
@@ -104,8 +104,8 @@ public final class ArchiveFileUtils {
     /**
      * Write contents of <code>buffer</code> to a temporary file, followed by the remaining bytes
      * in <code>channel</code>.
-     * <p/>
-     * <p>The bytes are read from <code>buffer</code> from the current position to its limit.
+     * 
+     * <p>The bytes are read from <code>buffer</code> from the current position to its limit.</p>
      *
      * @param buffer  contains the contents of the channel read so far
      * @param channel the rest of the channel
@@ -158,8 +158,8 @@ public final class ArchiveFileUtils {
     /**
      * Write contents of <code>buffer</code> to a temporary file, followed by the remaining bytes
      * in <code>channel</code>.
-     * <p/>
-     * <p>The bytes are read from <code>buffer</code> from the current position to its limit.
+     * 
+     * <p>The bytes are read from <code>buffer</code> from the current position to its limit.</p>
      *
      * @param tempDir the directory in which to create the temp file
      * @param buffer the initial buffer containing the first part of the file.

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolverImpl.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolverImpl.java
@@ -52,7 +52,7 @@ public class ArchiveFormatResolverImpl implements ArchiveFormatResolver {
     }
     
     /**
-     * Sets the format -> puid mapping.
+     * Sets the format -&gt; puid mapping.
      * 
      * @param puids the PUIDS to set
      */

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/FilterValue.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/FilterValue.java
@@ -94,27 +94,37 @@ public class FilterValue {
         this.queryParameter = queryParameter;
     }
 
-    /** Getter method for id. @return id Id of the reference data.*/
+    /** Getter method for id. 
+     * @return id Id of the reference data.
+    */
     public int getId() {
         return id;
     }
 
-    /** Setter method for id. @param id Id of the reference data. */
+    /** Setter method for id. 
+     * @param id Id of the reference data. 
+     */
     public void setId(int id) {
         this.id = id;
     }
 
-    /** Getter method for description. @return description  */
+    /** Getter method for description. 
+     * @return description  
+     */
     public String getDescription() {
         return description;
     }
 
-    /** Setter method for description. @param description Description of the reference data.*/
+    /** Setter method for description. 
+     * @param description Description of the reference data.
+    */
     public void setDescription(String description) {
         this.description = description;
     }
 
-    /** Overridden toString method. @return toString representation of Values (Reference Data)*/
+    /** Overridden toString method. 
+     * @return toString representation of Values (Reference Data)
+    */
     @Override
     public String toString() {
         return description;

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/MD5HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/MD5HashGenerator.java
@@ -44,7 +44,7 @@ public class MD5HashGenerator implements HashGenerator {
 
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException on failure to call md5Hex on Stream
      */
     @Override
     public String hash(InputStream in) throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/Sha256HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/Sha256HashGenerator.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2012, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.gov.nationalarchives.droid.core.interfaces.hash;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * @author gseaman
+ *
+ */
+public class Sha256HashGenerator implements HashGenerator {
+
+    /**
+     * {@inheritDoc}
+     * @throws IOException on failure to call sha256Hex on stream
+     */
+    @Override
+    public String hash(InputStream in) throws IOException {
+        return DigestUtils.sha256Hex(in);
+    }
+
+}
+

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/CachedByteArrays.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/CachedByteArrays.java
@@ -195,7 +195,7 @@ public final class CachedByteArrays implements CachedBytes {
 
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException on failure to open file
      */
     @Override
     public void setSourceFile(File sourceFile) throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequest.java
@@ -188,7 +188,7 @@ public class FileSystemIdentificationRequest implements IdentificationRequest {
     
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException  on failure to get InputStream
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequest.java
@@ -232,7 +232,7 @@ public class GZipIdentificationRequest implements IdentificationRequest {
     
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException on failure to get InputStream
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {
@@ -272,7 +272,7 @@ public class GZipIdentificationRequest implements IdentificationRequest {
 
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException on failure to create File from Stream
      */
     @Override
     public final File getSourceFile() throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/TarEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/TarEntryIdentificationRequest.java
@@ -231,7 +231,7 @@ public class TarEntryIdentificationRequest implements IdentificationRequest {
     
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException on failure to get InputStream
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {
@@ -241,7 +241,7 @@ public class TarEntryIdentificationRequest implements IdentificationRequest {
     
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException on failure to create File from InputStream
      */
     @Override
     public final File getSourceFile() throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ZipEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ZipEntryIdentificationRequest.java
@@ -234,7 +234,7 @@ public class ZipEntryIdentificationRequest implements IdentificationRequest {
 
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException on failure to get InputStream
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {
@@ -243,7 +243,7 @@ public class ZipEntryIdentificationRequest implements IdentificationRequest {
     
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException on failure to create File from InputStream
      */
     @Override
     public final File getSourceFile() throws IOException {

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/ByteReader.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/ByteReader.java
@@ -72,8 +72,8 @@ package uk.gov.nationalarchives.droid.core.signature;
 
 /**
  * Interface for accessing the bytes from a file, URL or stream.
- * <p/>
- * Create an instance with <code>AbstractByteReader.newByteReader()</code>.
+ * 
+ * <p>Create an instance with <code>AbstractByteReader.newByteReader()</code>.</p>
  *
  * @author linb
  */
@@ -168,9 +168,9 @@ public interface ByteReader {
 
     /**
      * Position the file marker at a given byte position.
-     * <p/>
-     * The file marker is used to record how far through the file
-     * the byte sequence matching algorithm has got.
+     * 
+     * <p>The file marker is used to record how far through the file
+     * the byte sequence matching algorithm has got.</p>
      *
      * @param markerPosition The byte number in the file at which to position the marker
      */

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/FileFormatHit.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/FileFormatHit.java
@@ -162,8 +162,8 @@ public class FileFormatHit extends SimpleElement {
 
     /**
      * Updates the warning message for a hit.
-     * <p/>
-     * Used by XML reader for IdentificationFile/FileFormatHit/IdentificationWarning element
+     * 
+     * <p>Used by XML reader for IdentificationFile/FileFormatHit/IdentificationWarning element</p>
      *
      * @param theWarning A warning associated with the hit
      */

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid4/ByteSeqSpecifier.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid4/ByteSeqSpecifier.java
@@ -58,6 +58,7 @@ public class ByteSeqSpecifier {
      *
      * @param asciiRep A StringBuffer whose initial portion will be an ASCII representation of the bytes specifier.  This will be
      *                 altered so that this initial portion is removed.
+     * @throws Exception on buffer indexing problems
      */
     public ByteSeqSpecifier(StringBuffer asciiRep) throws Exception {
         String specifier;    // The string of characters defining the bytes specifier (excluding any square brackets)
@@ -121,11 +122,11 @@ public class ByteSeqSpecifier {
      * @param direction +1 (left to right) or -1 (right to left).  The overall direction which our caller is searching in
      * @param bigEndian True iff the signature we are matching is big-endian
      * @return true iff the portion matches
-     *         <p/>
+     *         <p>
      *         Note: In an ideal world, we would hold bigEndian as a private member, set up on construction.  However, the framework
      *         used during parsing of the XML file does not lend itself to easily fetching information from a grandparent
      *         element.  Consequently, we parse the byte sequence specifier in ignorance of its endianness, and wait until
-     *         we try to match against a specific byte sequence (here) to find out how minSeq and maxSeq should be interpreted.
+     *         we try to match against a specific byte sequence (here) to find out how minSeq and maxSeq should be interpreted.</p>
      */
     public boolean matchesByteSequence(ByteReader file, long startPos, int direction, boolean bigEndian) {
         try {

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/ByteSequence.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/ByteSequence.java
@@ -92,15 +92,15 @@ import uk.gov.nationalarchives.droid.core.signature.ByteReader;
  * that can match a target file against itself, but operating
  * over bytes rather than text.
  * 
- * <p/>It is composed of a list of {@link SubSequence} objects,
+ * <p>It is composed of a list of {@link SubSequence} objects,
  * all of which must match for the ByteSequence as a whole to 
- * match.
+ * match.</p>
  * 
- * <p/>Subsequences are effectively individual strings of bytes
+ * <p>Subsequences are effectively individual strings of bytes
  * (albeit complex ones, including alternate strings and gaps), 
  * separated from each other by wildcard .* operators.  If there
  * are no .* operators in a ByteSequence, then there is only one
- * SubSequence.
+ * SubSequence.</p>
  *
  * @author Martin Waller
  * @version 6.0.0

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/FFSignatureFile.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/FFSignatureFile.java
@@ -113,8 +113,8 @@ import uk.gov.nationalarchives.droid.core.signature.xml.SimpleElement;
  * Holds all the file formats and binary signatures used to 
  * match them.
  * 
- * <p/>Can match a target file against all the binary signatures,
- * returning which file formats were hit when matching.
+ * <p>Can match a target file against all the binary signatures,
+ * returning which file formats were hit when matching.</p>
  * 
  * @author Martin Waller
  * @author Matt Palmer

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/FragmentRewriter.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/FragmentRewriter.java
@@ -35,17 +35,17 @@ package uk.gov.nationalarchives.droid.core.signature.droid6;
  * A utility class to transform DROID 4 expression fragments
  * into net.domesdaybook regular expressions. 
  *
- * <p/>The only syntactic different between a DROID 4 fragment and
- * net.domesdaybook expressions are in the definitions of sets.
+ * <p>The only syntactic different between a DROID 4 fragment and
+ * net.domesdaybook expressions are in the definitions of sets.</p>
  *
- * <p/>DROID 4 uses:
+ * <p>DROID 4 uses:
  *  * a ! to indicate an inverted set, whereas net.domesdaybook uses the more standard ^
- *  * a : to indicate a range of values, whereas net.domesdaybook uses the more standard -
+ *  * a : to indicate a range of values, whereas net.domesdaybook uses the more standard -</p>
  * 
- * <p/>net.domesdaybook regular expressions permit case sensitive
+ * <p>net.domesdaybook regular expressions permit case sensitive
  * strings delimited by single quotes ('), and case insensitive
  * strings delimited by back-ticks (`).  In case these are passed
- * in to the rewriter, it will ignore text between these delimiters.
+ * in to the rewriter, it will ignore text between these delimiters.</p>
  *  
  * @author Matt Palmer
  */

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignature.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignature.java
@@ -87,15 +87,15 @@ import uk.gov.nationalarchives.droid.core.signature.xml.SimpleElement;
 /**
  * A binary signature which can match one or more file formats.
  * 
- * <p/>It is composed of a list of {@link ByteSequence} objects,
- * which are like regular expressions that can match bytes.
+ * <p>It is composed of a list of {@link ByteSequence} objects,
+ * which are like regular expressions that can match bytes.</p>
  * 
- * <p/>A signature runs each ByteSequence against a target file, 
- * until one of them doesn't match, or all of them do. 
+ * <p>A signature runs each ByteSequence against a target file, 
+ * until one of them doesn't match, or all of them do.</p> 
  * 
- * <p/>It orders the ByteSequence objects to try to ensure 
+ * <p>It orders the ByteSequence objects to try to ensure 
  * optimal matching behaviour - e.g. the ones anchored to the 
- * start of the file are done before ones at the end of the file.
+ * start of the file are done before ones at the end of the file.</p>
  *
  * @author Martin Waller
  * @author Matt Palmer

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignatureComparator.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignatureComparator.java
@@ -38,9 +38,9 @@ import java.util.Comparator;
  * internal signatures being compared, to allow them to be
  * sorted for maximum performance.
  * 
- * <p/>To change the sort order of the signatures, change the
+ * <p>To change the sort order of the signatures, change the
  * sort order calculation in the {@link InternalSignature}
- * class itself, not this comparator.
+ * class itself, not this comparator.</p>
  * 
  * @author Matt Palmer
  */

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/LeftFragment.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/LeftFragment.java
@@ -65,11 +65,11 @@ package uk.gov.nationalarchives.droid.core.signature.droid6;
  * so their existence is checked for once an anchoring sequence 
  * has been found.
  * 
- * <p/>This subclass of SideFragment is only required so the XML
+ * <p>This subclass of SideFragment is only required so the XML
  * parser can build an instance of this class and assemble the
- * left fragments together.
+ * left fragments together.</p>
  * 
- * <p/>Left and Right Fragments are otherwise identical in functionality.
+ * <p>Left and Right Fragments are otherwise identical in functionality.</p>
  * 
  * @author Martin Waller
  * @author Matt Palmer.

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/RightFragment.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/RightFragment.java
@@ -65,11 +65,11 @@ package uk.gov.nationalarchives.droid.core.signature.droid6;
  * so their existence is checked for once an anchoring sequence 
  * has been found.
  * 
- * <p/>This subclass of SideFragment is only required so the XML
+ * <p>This subclass of SideFragment is only required so the XML
  * parser can build an instance of this class and assemble the
- * right fragments together.
+ * right fragments together.</p>
  * 
- * <p/>Left and Right Fragments are otherwise identical in functionality.
+ * <p>Left and Right Fragments are otherwise identical in functionality.</p>
  * 
  * @author Martin Waller
  * @author Matt Palmer

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SideFragment.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SideFragment.java
@@ -99,10 +99,10 @@ import uk.gov.nationalarchives.droid.core.signature.xml.SimpleElement;
  * algorithm.  Typically, this means parts of the subsequence
  * with gaps {n-m}, and alternatives (A|B|C).
  * 
- * <p/>A subsequence is defined by the longest anchoring sequence
+ * <p>A subsequence is defined by the longest anchoring sequence
  * which can be searched for, with any side fragments to the left
  * and right of it checked for after the anchoring sequence is 
- * found.  
+ * found. </p> 
  *
  * @author Martin Waller
  * @author Matt Palmer

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SubSequence.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SubSequence.java
@@ -131,11 +131,11 @@ import uk.gov.nationalarchives.droid.core.signature.xml.SimpleElement;
  * the BoyerMooreHorpsool (BMH) algorithm.  This is known as the
  * "anchor" sequence.  
  * 
- * <p/>If necessary, it can include Left and 
+ * <p>If necessary, it can include Left and 
  * Right Fragments, which are parts of the extended string of
  * bytes which cannot be searched for using BMH.  These fragments
  * include features like alternative (A|B|C) and gaps in the 
- * string, e.g. {5} or {5-10}.   
+ * string, e.g. {5} or {5-10}.</p>   
  * 
  * 
  * @author Martin Waller
@@ -263,16 +263,9 @@ public class SubSequence extends SimpleElement {
     }    
 
     /**
-     * Note: unclear whether this is used anymore.
-     * 
-     * @param theLength The minimum length of a fragment.
-     */
-    /*
-    public final void setMinFragLength(final int theLength) {
-        this.minFragLength = theLength;
-    }
-    */
-
+     * @param name Name of attribute to set
+     * @param value Value of attribute to set (may be ignored)
+     */ 
     @Override
     public final void setAttributeValue(final String name, final String value) {
         if ("SubSeqMinOffset".equals(name)) {
@@ -594,6 +587,7 @@ public class SubSequence extends SimpleElement {
      * the beginning or end of the file.  If negative, scanning is unlimited.
      * @param bofSubsequence Indicates when subsequence is anchored to BOF
      * @param eofSubsequence Indicates when subsequence is anchored to EOF
+     * @return boolean True on success
      */
     //CHECKSTYLE:OFF - far too complex method.
     public final boolean findSequenceFromPosition(final long position, 

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/xml/SAXModelBuilder.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/xml/SAXModelBuilder.java
@@ -121,12 +121,12 @@ public class SAXModelBuilder extends DefaultHandler {
 
     /**
      * Set up XML namespace handling.
-     * <p/>
+     * 
      * <p>If <code>allowGlobalNamespace</code> is set to <code>true</code>, elements
      * that do not have a namespace specified are parsed; attributes that don't
      * have a namespace specified are parsed.  If it is <code>false</code>, for
      * it to be parsed, an element must have a namespace specifed (by default or
-     * with a prefix); an attribute must have a namespace specified with a prefix.
+     * with a prefix); an attribute must have a namespace specified with a prefix.</p>
      *
      * @param nspace            the XML namespace to use
      * @param globalNamespace allow the parser to recognise elements/ attributes that aren't in any namespace

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -126,7 +126,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>2.9.1</version> <!-- >= 2.12 would get rid of the erroneous LICENSE.txt stack dumps in debug --> 
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -262,8 +262,8 @@
                         <exclude>**/DROID_SignatureFile_*.xml</exclude>
                         <exclude>**/container-signature*.xml</exclude>
                         <exclude>**/tmp/**</exclude>
-                        <exlcude>**/profiles/**</exlcude>
                         <exclude>**/droid-test-db/**</exclude>
+                        <exclude>**/package-info.java</exclude>
                     </excludes>
                 </configuration>
                 <executions>
@@ -365,6 +365,10 @@
                         <link>${project.url}</link>
                         <link>${project.organization.url}</link>
                     </links>
+                    <!-- this won't work till version 2.11 is released -->
+                    <sourceFileExcludes>
+                        <exclude>**/package-info.java</exclude>
+                    </sourceFileExcludes>    
                     <packagesheader>DROID Packages</packagesheader>
                     <doctitle>DROID 6.1.5-SNAPSHOT</doctitle>
                     <windowtitle>DROID 6.1.5-SNAPSHOT</windowtitle>

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ByFormatType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ByFormatType.java
@@ -52,15 +52,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType name="ByFormatType">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;choice maxOccurs="unbounded" minOccurs="0">
- *         &lt;element name="formatItem" type="{http://www.nationalarchives.gov.uk/CollectionProfile}FormatItemType"/>
- *       &lt;/choice>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType name="ByFormatType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice maxOccurs="unbounded" minOccurs="0"&gt;
+ *         &lt;element name="formatItem" type="{http://www.nationalarchives.gov.uk/CollectionProfile}FormatItemType"/&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * @deprecated PLANETS XML is now generated using XSLT over normal report xml files.
@@ -93,7 +93,7 @@ public class ByFormatType {
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link FormatItemType }
-     * 
+     * @return List
      * 
      */
     public List<FormatItemType> getFormatItem() {

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ByYearType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ByYearType.java
@@ -52,15 +52,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType name="ByYearType">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;choice maxOccurs="unbounded" minOccurs="0">
- *         &lt;element name="yearItem" type="{http://www.nationalarchives.gov.uk/CollectionProfile}YearItemType"/>
- *       &lt;/choice>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType name="ByYearType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice maxOccurs="unbounded" minOccurs="0"&gt;
+ *         &lt;element name="yearItem" type="{http://www.nationalarchives.gov.uk/CollectionProfile}YearItemType"/&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  *  * @deprecated PLANETS XML is now generated using XSLT over normal report xml files.
@@ -94,7 +94,7 @@ public class ByYearType {
      * Objects of the following type(s) are allowed in the list
      * {@link YearItemType }
      * 
-     * 
+     * @return List
      */
     public List<YearItemType> getYearItem() {
         if (yearItem == null) {

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/FileProfileType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/FileProfileType.java
@@ -54,27 +54,27 @@ import javax.xml.datatype.XMLGregorianCalendar;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType name="FileProfileType">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="profilingStartDate" type="{http://www.w3.org/2001/XMLSchema}dateTime"/>
- *         &lt;element name="profilingEndDate" type="{http://www.w3.org/2001/XMLSchema}dateTime"/>
- *         &lt;element name="profilingSaveDate" type="{http://www.w3.org/2001/XMLSchema}dateTime"/>
- *         &lt;element name="totalReadableFiles" type="{http://www.w3.org/2001/XMLSchema}integer"/>
- *         &lt;element name="totalUnreadableFiles" type="{http://www.w3.org/2001/XMLSchema}integer"/>
- *         &lt;element name="totalUnreadableFolders" type="{http://www.w3.org/2001/XMLSchema}integer"/>
- *         &lt;element name="totalSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/>
- *         &lt;element name="smallestSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/>
- *         &lt;element name="largestSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/>
- *         &lt;element name="meanSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/>
- *         &lt;element name="pathsProcessed" type="{http://www.nationalarchives.gov.uk/CollectionProfile}PathsProcessedType"/>
- *         &lt;element name="byYear" type="{http://www.nationalarchives.gov.uk/CollectionProfile}ByYearType"/>
- *         &lt;element name="byFormat" type="{http://www.nationalarchives.gov.uk/CollectionProfile}ByFormatType"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType name="FileProfileType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="profilingStartDate" type="{http://www.w3.org/2001/XMLSchema}dateTime"/&gt;
+ *         &lt;element name="profilingEndDate" type="{http://www.w3.org/2001/XMLSchema}dateTime"/&gt;
+ *         &lt;element name="profilingSaveDate" type="{http://www.w3.org/2001/XMLSchema}dateTime"/&gt;
+ *         &lt;element name="totalReadableFiles" type="{http://www.w3.org/2001/XMLSchema}integer"/&gt;
+ *         &lt;element name="totalUnreadableFiles" type="{http://www.w3.org/2001/XMLSchema}integer"/&gt;
+ *         &lt;element name="totalUnreadableFolders" type="{http://www.w3.org/2001/XMLSchema}integer"/&gt;
+ *         &lt;element name="totalSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/&gt;
+ *         &lt;element name="smallestSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/&gt;
+ *         &lt;element name="largestSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/&gt;
+ *         &lt;element name="meanSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/&gt;
+ *         &lt;element name="pathsProcessed" type="{http://www.nationalarchives.gov.uk/CollectionProfile}PathsProcessedType"/&gt;
+ *         &lt;element name="byYear" type="{http://www.nationalarchives.gov.uk/CollectionProfile}ByYearType"/&gt;
+ *         &lt;element name="byFormat" type="{http://www.nationalarchives.gov.uk/CollectionProfile}ByFormatType"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * @deprecated PLANETS XML is now generated using XSLT over normal report xml files. 

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/FormatItemType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/FormatItemType.java
@@ -53,20 +53,20 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType name="FormatItemType">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="PUID" type="{http://www.w3.org/2001/XMLSchema}string"/>
- *         &lt;element name="MIME" type="{http://www.w3.org/2001/XMLSchema}string"/>
- *         &lt;element name="FormatName" type="{http://www.w3.org/2001/XMLSchema}string"/>
- *         &lt;element name="FormatVersion" type="{http://www.w3.org/2001/XMLSchema}string"/>
- *         &lt;element name="numFiles" type="{http://www.w3.org/2001/XMLSchema}integer"/>
- *         &lt;element name="totalFileSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType name="FormatItemType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="PUID" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
+ *         &lt;element name="MIME" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
+ *         &lt;element name="FormatName" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
+ *         &lt;element name="FormatVersion" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
+ *         &lt;element name="numFiles" type="{http://www.w3.org/2001/XMLSchema}integer"/&gt;
+ *         &lt;element name="totalFileSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * @deprecated PLANETS XML is now generated using XSLT over normal report xml files. 

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ObjectFactory.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ObjectFactory.java
@@ -75,7 +75,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link ByFormatType }
-     * 
+     * @return ByFormatType
      */
     public ByFormatType createByFormatType() {
         return new ByFormatType();
@@ -83,7 +83,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link PathsProcessedType }
-     * 
+     * @return PathsProcessedType
      */
     public PathsProcessedType createPathsProcessedType() {
         return new PathsProcessedType();
@@ -91,7 +91,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link FileProfileType }
-     * 
+     * @return FileProfileType
      */
     public FileProfileType createFileProfileType() {
         return new FileProfileType();
@@ -99,7 +99,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link FormatItemType }
-     * 
+     * @return FormatItemType
      */
     public FormatItemType createFormatItemType() {
         return new FormatItemType();
@@ -107,7 +107,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link ByYearType }
-     * 
+     * @return ByYearType
      */
     public ByYearType createByYearType() {
         return new ByYearType();
@@ -115,7 +115,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link YearItemType }
-     * 
+     * @return YearItemType
      */
     public YearItemType createYearItemType() {
         return new YearItemType();
@@ -123,7 +123,8 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link FileProfileType }{@code >}}
-     * 
+     * @param value FileProfileType
+     * @return JAXBElement for File Profile
      */
     @XmlElementDecl(namespace = "http://www.nationalarchives.gov.uk/CollectionProfile", name = "FileProfile")
     public JAXBElement<FileProfileType> createFileProfile(FileProfileType value) {

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/PathsProcessedType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/PathsProcessedType.java
@@ -52,15 +52,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType name="PathsProcessedType">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;choice maxOccurs="unbounded" minOccurs="0">
- *         &lt;element name="pathItem" type="{http://www.w3.org/2001/XMLSchema}string"/>
- *       &lt;/choice>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType name="PathsProcessedType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice maxOccurs="unbounded" minOccurs="0"&gt;
+ *         &lt;element name="pathItem" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * @deprecated PLANETS XML is now generated using XSLT over normal report xml files. 
@@ -94,7 +94,7 @@ public class PathsProcessedType {
      * Objects of the following type(s) are allowed in the list
      * {@link String }
      * 
-     * 
+     * @return List
      */
     public List<String> getPathItem() {
         if (pathItem == null) {

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/YearItemType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/YearItemType.java
@@ -55,17 +55,17 @@ import javax.xml.datatype.XMLGregorianCalendar;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType name="YearItemType">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="year" type="{http://www.w3.org/2001/XMLSchema}gYear"/>
- *         &lt;element name="numFiles" type="{http://www.w3.org/2001/XMLSchema}integer"/>
- *         &lt;element name="totalFileSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType name="YearItemType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="year" type="{http://www.w3.org/2001/XMLSchema}gYear"/&gt;
+ *         &lt;element name="numFiles" type="{http://www.w3.org/2001/XMLSchema}integer"/&gt;
+ *         &lt;element name="totalFileSize" type="{http://www.w3.org/2001/XMLSchema}decimal"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * @deprecated PLANETS XML is now generated using XSLT over normal report xml files. 

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/package-info.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2012, The National Archives &lt;mailto:pronom@nationalarchives.gsi.gov.uk/&gt;
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/checkstyle/suppressions.xml
+++ b/droid-results/checkstyle/suppressions.xml
@@ -68,6 +68,10 @@
     <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling"
               files=".*ProfileInstanceManagerImpl\.java$"/>
 
+    <!-- suppress requirement for @return on enum, which conflicts with new XDocLint -->
+    <suppress checks="JavadocMethodCheck"
+              files=".*ProfileState\.java$"/>
+
     <suppress checks="ThrowsCount"
               files=".*ProfileSpecWalker(Impl)*\.java$"/>
 

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImpl.java
@@ -159,8 +159,9 @@ public class ProfileManagerImpl implements ProfileManager {
 
     /**
      * {@inheritDoc}
-     * 
-     * @throws SignatureFileException
+     * @param profileId String
+     * @throws IllegalArgumentException if profileId nonexistent
+     * @return Profile
      */
     @Override
     public ProfileInstance openProfile(String profileId) {
@@ -178,8 +179,7 @@ public class ProfileManagerImpl implements ProfileManager {
 
     /**
      * {@inheritDoc}
-     * 
-     * @throws SignatureFileException
+     * @param profileInstance The profile to stop
      */
     @Override
     public void stop(String profileInstance) {
@@ -189,9 +189,9 @@ public class ProfileManagerImpl implements ProfileManager {
     }
 
     /**
-     * @param profileInstance
-     * @return
-     * @throws SignatureFileException
+     * @param profileInstance String
+     * @return ProfileInstanceManager
+     * @throws ProfileException if null profileInstance
      */
     private ProfileInstanceManager getProfileInstanceManager(
             String profileInstance) {

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileState.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileState.java
@@ -40,44 +40,44 @@ import java.util.Collection;
  */
 public enum ProfileState {
     
-    /** @return The profile is running. */
+    /** The profile is running. */
     RUNNING(true) { @Override 
         ProfileState[] nextStates() {
             return new ProfileState[] {STOPPED, FINISHED};
         }
     },
     
-    /** @return The profile has been stopped. */
+    /** The profile has been stopped. */
     STOPPED(false, true) { @Override ProfileState[] nextStates() {
             return new ProfileState[] {RUNNING, SAVING, FINISHED};
         }
     },
     
-    /** @return The profile is saving to disk. */
+    /** The profile is saving to disk. */
     SAVING(true) { @Override ProfileState[] nextStates() {
             return new ProfileState[] {VIRGIN, STOPPED, FINISHED};
         }
     },
     
-    /** @return The profile is loading from disk. */
+    /** The profile is loading from disk. */
     LOADING(true) { @Override ProfileState[] nextStates() {
             return new ProfileState[] {VIRGIN, STOPPED, FINISHED};
         }
     },
     
-    /** @return The profile is being initialised. */
+    /** The profile is being initialised. */
     INITIALISING(true) { @Override ProfileState[] nextStates() {
             return new ProfileState[] {VIRGIN, STOPPED, FINISHED};
         }
     }, 
     
-    /** @return The profile has never been run. */
+    /** The profile has never been run. */
     VIRGIN(false) { @Override ProfileState[] nextStates() {
             return new ProfileState[] {RUNNING, SAVING};
         }
     },
 
-    /** @return The profile has finished. */
+    /** The profile has finished. */
     FINISHED(false, true) { @Override ProfileState[] nextStates() {
             return new ProfileState[] {SAVING};
         }
@@ -109,7 +109,6 @@ public enum ProfileState {
     
     /**
      * @return True if this is a transient state, false otherwise.
-     * @return
      */
     public boolean isTransient() {
         return isTransient;
@@ -117,7 +116,7 @@ public enum ProfileState {
     
     /**
      * 
-     * @return true if theis profile state allows reporting; false otherwise.
+     * @return true if this profile state allows reporting; false otherwise.
      */
     public boolean isReportable() {
         return reportable;

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSource.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSource.java
@@ -95,7 +95,6 @@ public class DerbyPooledDataSource extends BasicDataSource {
     * Derby throws a SQLNonTransientConnectionException on a SUCCESSFUL shutdown of the
     * database (with SQLstate 08006), so we catch this and log as debug, otherwise as an error.
     * @throws SQLException if the database could not be shutdown.
-    * @throws Exception
     */
     public void shutdown() throws SQLException {
 

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/HibernateItemReader.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/HibernateItemReader.java
@@ -48,7 +48,7 @@ import uk.gov.nationalarchives.droid.export.interfaces.JobCancellationException;
 
 /**
  * @author rflitcroft
- * @param <T>
+ * @param <T> type of Item to read
  *
  */
 public class HibernateItemReader<T> implements ItemReader<T> {
@@ -85,7 +85,7 @@ public class HibernateItemReader<T> implements ItemReader<T> {
     
     /**
      * {@inheritDoc}
-     * @throws JobCancellationException 
+     * @throws JobCancellationException if cancelled
      */
     @Override
     //@Transactional(propagation = Propagation.REQUIRED)

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/SqlItemReader.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/SqlItemReader.java
@@ -51,7 +51,7 @@ import uk.gov.nationalarchives.droid.profile.SqlUtils;
 
 /**
  * @author a-mpalmer
- * @param <T>
+ * @param <T> type of Item to read
  */
 public class SqlItemReader<T> implements ItemReader<T> {
 
@@ -86,7 +86,7 @@ public class SqlItemReader<T> implements ItemReader<T> {
     /**
      * {@inheritDoc}
      * 
-     * @throws JobCancellationException
+     * @throws JobCancellationException if cancelled
      */
     @Override
     // @Transactional(propagation = Propagation.REQUIRED)

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/types/UriType.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/types/UriType.java
@@ -85,8 +85,8 @@ public class UriType extends AbstractSingleColumnStandardBasicType<URI> implemen
     /**
      * @param value - the URI to convert to string.
      * @param dialect - the dialect to use.
-     * @return - SQL String.
-     * @throws Exception 
+     * @return - SQL String
+     * @throws Exception if conversion fails
      */
     public String objectToSQLString(URI value, Dialect dialect) throws Exception {
 

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/types/UriTypeDescriptor.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/types/UriTypeDescriptor.java
@@ -102,7 +102,7 @@ public class UriTypeDescriptor extends AbstractTypeDescriptor<URI> {
 
     /**
      * @param <X> - type to wrap to a URI.
-     * @param value - value to wrap, of type <X> .
+     * @param value - value to wrap, of type X .
      * @param options - not used.
      * @return - URI from generic type.
      */

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/SignatureManagerImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/SignatureManagerImpl.java
@@ -375,7 +375,7 @@ public class SignatureManagerImpl implements SignatureManager {
     
     /**
      * {@inheritDoc}
-     * @throws SignatureFileException 
+     * @throws SignatureFileException on failure to retrieve signatures
      */
     @Override
     public Map<SignatureType, SignatureFileInfo> getDefaultSignatures() throws SignatureFileException {

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileV1.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileV1.java
@@ -44,14 +44,14 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileV1Response.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileV1Response.java
@@ -47,15 +47,15 @@ import uk.gov.nationalarchives.pronom.signaturefile.XmlFragment;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="SignatureFile" type="{http://www.nationalarchives.gov.uk/pronom/SignatureFile}SigFile"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="SignatureFile" type="{http://www.nationalarchives.gov.uk/pronom/SignatureFile}SigFile"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 
@@ -74,8 +74,7 @@ public class GetSignatureFileV1Response {
      * Gets the value of the signatureFile property.
      * 
      * @return
-     *     possible object is
-     *     {@link SigFile }
+     *     possible object is XmlFragment
      *     
      */
     public XmlFragment getSignatureFile() {
@@ -86,8 +85,7 @@ public class GetSignatureFileV1Response {
      * Sets the value of the signatureFile property.
      * 
      * @param value
-     *     allowed object is
-     *     {@link SigFile }
+     *     allowed object is XmlFragment
      *     
      */
     public void setSignatureFile(XmlFragment value) {

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileVersionV1.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileVersionV1.java
@@ -44,14 +44,14 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileVersionV1Response.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileVersionV1Response.java
@@ -45,16 +45,16 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="Version" type="{http://pronom.nationalarchives.gov.uk}Version"/>
- *         &lt;element name="Deprecated" type="{http://www.w3.org/2001/XMLSchema}boolean"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="Version" type="{http://pronom.nationalarchives.gov.uk}Version"/&gt;
+ *         &lt;element name="Deprecated" type="{http://www.w3.org/2001/XMLSchema}boolean"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 
@@ -98,7 +98,8 @@ public class GetSignatureFileVersionV1Response {
 
     /**
      * Gets the value of the deprecated property.
-     * 
+     *
+     * @return boolean True if deprecated 
      */
     public boolean isDeprecated() {
         return deprecated;
@@ -106,7 +107,7 @@ public class GetSignatureFileVersionV1Response {
 
     /**
      * Sets the value of the deprecated property.
-     * 
+     * @param value True if deprecated
      */
     public void setDeprecated(boolean value) {
         this.deprecated = value;

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/ObjectFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/ObjectFactory.java
@@ -62,7 +62,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link GetSignatureFileVersionV1Response }
-     * 
+     * @return SignatureFileVersionV1Response 
      */
     public GetSignatureFileVersionV1Response createGetSignatureFileVersionV1Response() {
         return new GetSignatureFileVersionV1Response();
@@ -70,6 +70,8 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Version }
+     *
+     * @return Version
      * 
      */
     public Version createVersion() {
@@ -79,6 +81,7 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link GetSignatureFileV1 }
      * 
+     * @return GetSignatureFileV1
      */
     public GetSignatureFileV1 createGetSignatureFileV1() {
         return new GetSignatureFileV1();
@@ -87,6 +90,7 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link GetSignatureFileVersionV1 }
      * 
+     * @return GetSignatureFileVersionV1
      */
     public GetSignatureFileVersionV1 createGetSignatureFileVersionV1() {
         return new GetSignatureFileVersionV1();
@@ -95,6 +99,7 @@ public class ObjectFactory {
     /**
      * Create an instance of {@link GetSignatureFileV1Response }
      * 
+     * @return GetSignatureFileV1Response
      */
     public GetSignatureFileV1Response createGetSignatureFileV1Response() {
         return new GetSignatureFileV1Response();

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/Version.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/Version.java
@@ -44,15 +44,15 @@ import javax.xml.bind.annotation.XmlType;
  * <p>The following schema fragment specifies the expected content contained within this class.
  * 
  * <pre>
- * &lt;complexType name="Version">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="Version" type="{http://www.w3.org/2001/XMLSchema}int"/>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
+ * &lt;complexType name="Version"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="Version" type="{http://www.w3.org/2001/XMLSchema}int"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
  * </pre>
  * 
  * 
@@ -68,7 +68,7 @@ public class Version {
 
     /**
      * Gets the value of the version property.
-     * 
+     * @return int
      */
     public int getVersion() {
         return version;
@@ -76,7 +76,7 @@ public class Version {
 
     /**
      * Sets the value of the version property.
-     * 
+     * @param value integer
      */
     public void setVersion(int value) {
         this.version = value;

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/package-info.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2012, The National Archives &lt;mailto:pronom@nationalarchives.gsi.gov.uk/&gt;
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/ObjectFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/ObjectFactory.java
@@ -61,7 +61,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlFragment }
-     * 
+     * @return XmlFragment
      */
     public XmlFragment createXmlFragment() {
         return new XmlFragment();

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/package-info.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2012, The National Archives &lt;mailto:pronom@nationalarchives.gsi.gov.uk/&gt;
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/CheckListRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/CheckListRenderer.java
@@ -50,7 +50,6 @@ public class CheckListRenderer extends JCheckBox implements ListCellRenderer {
     }
 
     /**
-     * @Override
      * {@inheritDoc}
      * 
      */

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FormatCountMetaData.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FormatCountMetaData.java
@@ -43,7 +43,6 @@ public class FormatCountMetaData extends GenericMetadata {
     private static final int ALLOWEDNOOFDIGITS = 18;
     
     /**
-     * @param metadataName
      */
     public FormatCountMetaData() {
         super(CriterionFieldEnum.IDENTIFICATION_COUNT);

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/OutlineComparableComparator.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/OutlineComparableComparator.java
@@ -38,7 +38,7 @@ import org.netbeans.swing.etable.ETableColumn;
  * sorts directories first.
  * @author rflitcroft
  *
- * @param <T>
+ * @param <T> type of DirectoryComparable objects
  */
 public class OutlineComparableComparator<T extends DirectoryComparable<T>> implements DirectoryComparator<T> {
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
                 <configuration>
                     <header>droid-parent/header.txt</header>
                     <aggregate>false</aggregate>
+                    <excludes>
+                         <exclude>.idea/**</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Java8 has a stricter version of the javadoc Linter; this was the cause of the original compilation error reported in issue #54. These text edits fix the Linter problems. They do not affect the ANTL problem, which still prevents compilation with Java8.