### PR TITLE
Relaxed rules on allowable urls in Arc files

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2012, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.gov.nationalarchives.droid.command.archive;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import uk.gov.nationalarchives.droid.container.ContainerSignatureDefinitions;
+import uk.gov.nationalarchives.droid.command.ResultPrinter;
+import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
+import uk.gov.nationalarchives.droid.core.BinarySignatureIdentifier;
+import uk.gov.nationalarchives.droid.core.interfaces.IdentificationRequest;
+import uk.gov.nationalarchives.droid.core.interfaces.IdentificationResultCollection;
+
+/**
+ * Parent class for Containers.
+ *
+ * @author G.Seaman
+ *
+ */
+
+public abstract class ArchiveContentIdentifier {
+
+    private String slash;
+    private String slash1;
+    private BinarySignatureIdentifier binarySignatureIdentifier;
+    private ContainerSignatureDefinitions containerSignatureDefinitions;
+    private File tmpDir;
+    private String path;
+    private Boolean expandWebArchives;
+
+
+    /**
+     * Initialization of instance values must be explicitly called by all children.
+     * @param binarySignatureIdentifier     binary signature identifier
+     * @param containerSignatureDefinitions container signatures
+     * @param path                          current archive path
+     * @param slash                         local path element delimiter
+     * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand (W)ARC files
+     */
+    public ArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
+                                       final ContainerSignatureDefinitions containerSignatureDefinitions,
+                                       final String path, final String slash, final String slash1,
+                                       final Boolean expandWebArchives) {
+
+        synchronized (this) {
+            setBinarySignatureIdentifier(binarySignatureIdentifier);
+            setContainerSignatureDefinitions(containerSignatureDefinitions);
+            setPath(path);
+            setSlash(slash);
+            setSlash1(slash1);
+            setExpandWebArchives(expandWebArchives);
+            if (getTmpDir() == null) {
+                setTmpDir(new File(System.getProperty("java.io.tmpdir")));
+            }
+        }
+    }
+    /**
+     * @return local path element delimiter
+     */
+    protected String getSlash() {
+        return slash;
+    }
+    /**
+     * @param newSlash path element delimiter
+     */
+    protected void setSlash(String newSlash) {
+        this.slash = newSlash;
+    }
+    /**
+     * @return container element delimiter
+     */
+    protected String getSlash1() {
+        return  slash1;
+    }
+    /**
+     * @param newSlash1 container element delimiter
+     */
+    protected void setSlash1(String newSlash1) {
+        this.slash1 = newSlash1;
+    }
+    /**
+     * @return binary signature identifier
+     */
+    protected BinarySignatureIdentifier getBinarySignatureIdentifier() {
+        return  binarySignatureIdentifier;
+    }
+    /**
+     * @param bis binary signature identifier
+     */
+    protected void setBinarySignatureIdentifier(BinarySignatureIdentifier bis) {
+        this.binarySignatureIdentifier = bis;
+    }
+    /**
+     * @return container signatures
+     */
+    protected ContainerSignatureDefinitions getContainerSignatureDefinitions() {
+        return containerSignatureDefinitions;
+    }
+    /**
+     * @param csd container signatures
+     */
+    protected void setContainerSignatureDefinitions(ContainerSignatureDefinitions csd) {
+        this.containerSignatureDefinitions = csd;
+    }
+
+    /**
+     * @return temporary file directory
+     */
+    protected File getTmpDir() {
+        return tmpDir;
+    }
+    /**
+     * @param tmpDir temporary file directory
+     */
+    protected void setTmpDir(File tmpDir) {
+        this.tmpDir = tmpDir;
+    }
+    /**
+     * @return archive path
+     */
+    protected String getPath() {
+        return path;
+    }
+    /**
+     * @param path archive path
+     */
+    protected void setPath(String path) {
+        this.path = path;
+    }
+    /**
+     * @return whether to expand (W)ARCs
+     */
+    protected Boolean getExpandWebArchives() {
+        return expandWebArchives;
+    }
+    /**
+     * @param ewa whether to expand (W)ARCs
+     */
+    protected void setExpandWebArchives(Boolean ewa) {
+        this.expandWebArchives = ewa;
+    }
+
+    /**
+     *
+     * @param prefix    String describing container-type
+     * @param filename  Name of file
+     * @return URI for container
+     */
+    protected String makeContainerURI(String prefix, String filename) {
+        return prefix + ":" + getSlash1() + getPath() + filename + "!" + getSlash();
+    }
+
+    /**
+     * @param request  The request
+     * @param in The container input stream
+     * @param newPath Path for the Container file
+     * @throws CommandExecutionException When an exception happens during execution
+     */
+    protected void expandContainer(IdentificationRequest request, InputStream in, String newPath)
+        throws CommandExecutionException {
+
+        try {
+            request.open(in);
+            final IdentificationResultCollection results =
+                    getBinarySignatureIdentifier().matchBinarySignatures(request);
+            // CHECKSTYLE:OFF
+            final ResultPrinter resultPrinter =
+                    new ResultPrinter(getBinarySignatureIdentifier(),
+                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true, getExpandWebArchives());
+            // CHECKSTYLE:ON
+            resultPrinter.print(results, request);
+            request.close();
+        }  catch (IOException ioe) {
+            System.err.println(ioe + " " + newPath); // continue after corrupt archive
+        } finally {
+            try {
+                // make sure no temp files are left behind
+                request.close();
+            } catch (IOException ioe) {
+                System.err.println("Failed to close temp file for Container request:" + ioe);
+                // not a lot we can do here - warning msg already given and deleteOnExit set
+            }
+        }
+    }
+
+}

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
@@ -31,7 +31,6 @@
  */
 package uk.gov.nationalarchives.droid.command.archive;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -39,12 +38,10 @@ import java.net.URI;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
-import uk.gov.nationalarchives.droid.command.ResultPrinter;
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureDefinitions;
 import uk.gov.nationalarchives.droid.core.BinarySignatureIdentifier;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationRequest;
-import uk.gov.nationalarchives.droid.core.interfaces.IdentificationResultCollection;
 import uk.gov.nationalarchives.droid.core.interfaces.RequestIdentifier;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.RequestMetaData;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.TarEntryIdentificationRequest;
@@ -54,15 +51,8 @@ import uk.gov.nationalarchives.droid.core.interfaces.resource.TarEntryIdentifica
  * 
  * @author rbrennan
  */
-public class TarArchiveContentIdentifier {
+public class TarArchiveContentIdentifier extends ArchiveContentIdentifier {
 
-    private BinarySignatureIdentifier binarySignatureIdentifier;
-    private ContainerSignatureDefinitions containerSignatureDefinitions;
-    private String path;
-    private String slash;
-    private String slash1;
-    private File tmpDir;
-    
     /**
      * 
      * @param binarySignatureIdentifier     binary signature identifier
@@ -75,16 +65,7 @@ public class TarArchiveContentIdentifier {
             final ContainerSignatureDefinitions containerSignatureDefinitions,
             final String path, final String slash, final String slash1) {
     
-        synchronized (this) {
-            this.binarySignatureIdentifier = binarySignatureIdentifier;
-            this.containerSignatureDefinitions = containerSignatureDefinitions;
-            this.path = path;
-            this.slash = slash;
-            this.slash1 = slash1;
-            if (tmpDir == null) {
-                tmpDir = new File(System.getProperty("java.io.tmpdir"));
-            }
-        }
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash, false);
     }
     
     /**
@@ -95,9 +76,9 @@ public class TarArchiveContentIdentifier {
      */
     public void identify(final URI uri, final IdentificationRequest request)
         throws CommandExecutionException {
-        
-        final String newPath = "tar:" + slash1 + path + request.getFileName() + "!" + slash;
-        slash1 = "";
+
+        final String newPath = makeContainerURI("tar", request.getFileName());
+        setSlash1("");
         InputStream tarIn = null; 
         try {
             tarIn = request.getSourceInputStream(); 
@@ -110,15 +91,8 @@ public class TarArchiveContentIdentifier {
                         final RequestMetaData metaData = new RequestMetaData(1L, 2L, name);
                         final RequestIdentifier identifier = new RequestIdentifier(uri);
                         final TarEntryIdentificationRequest tarRequest =
-                            new TarEntryIdentificationRequest(metaData, identifier, tmpDir);
-                        tarRequest.open(in);
-                        final IdentificationResultCollection tarResults =
-                                binarySignatureIdentifier.matchBinarySignatures(tarRequest);
-                        final ResultPrinter resultPrinter =
-                                new ResultPrinter(binarySignatureIdentifier,
-                                    containerSignatureDefinitions, newPath, slash, slash1, true, false);
-                        resultPrinter.print(tarResults, tarRequest);
-                        tarRequest.close();
+                            new TarEntryIdentificationRequest(metaData, identifier, getTmpDir());
+                        expandContainer(tarRequest, in, newPath);
                     }
                 }
             } finally {

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
@@ -31,7 +31,6 @@
  */
 package uk.gov.nationalarchives.droid.command.archive;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -39,12 +38,10 @@ import java.net.URI;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 
-import uk.gov.nationalarchives.droid.command.ResultPrinter;
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureDefinitions;
 import uk.gov.nationalarchives.droid.core.BinarySignatureIdentifier;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationRequest;
-import uk.gov.nationalarchives.droid.core.interfaces.IdentificationResultCollection;
 import uk.gov.nationalarchives.droid.core.interfaces.RequestIdentifier;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.RequestMetaData;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.ZipEntryIdentificationRequest;
@@ -54,15 +51,9 @@ import uk.gov.nationalarchives.droid.core.interfaces.resource.ZipEntryIdentifica
  * 
  * @author rbrennan
  */
-public class ZipArchiveContentIdentifier {
+public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
 
-    private BinarySignatureIdentifier binarySignatureIdentifier;
-    private ContainerSignatureDefinitions containerSignatureDefinitions;
-    private String path;
-    private String slash;
-    private String slash1;
-    private File tmpDir;
-    
+
     /**
      * 
      * @param binarySignatureIdentifier     binary signature identifier
@@ -75,16 +66,8 @@ public class ZipArchiveContentIdentifier {
             final ContainerSignatureDefinitions containerSignatureDefinitions,
             final String path, final String slash, final String slash1) {
     
-        synchronized (this) {
-            this.binarySignatureIdentifier = binarySignatureIdentifier;
-            this.containerSignatureDefinitions = containerSignatureDefinitions;
-            this.path = path;
-            this.slash = slash;
-            this.slash1 = slash1;
-            if (tmpDir == null) {
-                tmpDir = new File(System.getProperty("java.io.tmpdir"));
-            }
-        }
+            super(binarySignatureIdentifier, containerSignatureDefinitions,
+        path, slash, slash1, false);
     }
     
     /**
@@ -95,9 +78,9 @@ public class ZipArchiveContentIdentifier {
      */
     public void identify(final URI uri, final IdentificationRequest request)
         throws CommandExecutionException {
-        
-        final String newPath = "zip:" + slash1 + path + request.getFileName() + "!" + slash;
-        slash1 = "";
+
+        final String newPath = makeContainerURI("zip", request.getFileName());
+        setSlash1("");
         InputStream zipIn = null; 
         try {
             zipIn = request.getSourceInputStream(); 
@@ -110,16 +93,8 @@ public class ZipArchiveContentIdentifier {
                         final RequestMetaData metaData = new RequestMetaData(1L, 2L, name);
                         final RequestIdentifier identifier = new RequestIdentifier(uri);
                         final ZipEntryIdentificationRequest zipRequest =
-                            new ZipEntryIdentificationRequest(metaData, identifier, tmpDir);
-                        
-                        zipRequest.open(in);
-                        final IdentificationResultCollection zipResults =
-                                binarySignatureIdentifier.matchBinarySignatures(zipRequest);
-                        final ResultPrinter resultPrinter =
-                                new ResultPrinter(binarySignatureIdentifier,
-                                    containerSignatureDefinitions, newPath, slash, slash1, true, false);
-                        resultPrinter.print(zipResults, zipRequest);
-                        zipRequest.close();
+                            new ZipEntryIdentificationRequest(metaData, identifier, getTmpDir());
+                        expandContainer(zipRequest, in, newPath);
                     }
                 }
             } finally {
@@ -140,3 +115,4 @@ public class ZipArchiveContentIdentifier {
         }
     }
 }
+

--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.jwat</groupId>
             <artifactId>jwat-arc</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.jwat</groupId>

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArcArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArcArchiveHandler.java
@@ -185,7 +185,8 @@ public class ArcArchiveHandler extends WebArchiveHandler implements ArchiveHandl
         protected void handleEntry(ArcRecordBase entry) throws IOException {
             final int maxLEN = 4095;
 
-            String entryUri = entry.getUrl().toString();
+            //String entryUri = entry.getUrl().toString();
+            String entryUri = entry.getUrlStr();
             String entryPath = new URL(entryUri).getFile();
             // remove querystring to get prefix (may include slashes)
             final int queryPos = entryPath.indexOf('?');

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalProperty.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalProperty.java
@@ -99,7 +99,7 @@ public enum DroidGlobalProperty {
     PROCESS_ARCHIVES("profile.processArchives", PropertyType.BOOLEAN, true),
 
     /** Whether to process files in web archives. */
-    PROCESS_WEB_ARCHIVES("profile.processWebArchives", PropertyType.BOOLEAN, false),
+    PROCESS_WEB_ARCHIVES("profile.processWebArchives", PropertyType.BOOLEAN, true),
 
     /** Whether to process files in archives. */
     PUID_URL_PATTERN("puid.urlPattern", PropertyType.TEXT, true), 

--- a/droid-results/src/main/resources/META-INF/spring-results.xml
+++ b/droid-results/src/main/resources/META-INF/spring-results.xml
@@ -261,7 +261,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
         <property name="containerIdentifierFactory" ref="containerIdentifierLocator"/>
         <property name="executorService" ref="coreExecutorService"/>
         <property name="processArchives" value="${processArchives}"/>
-        <property name="processWebArchives" value="${processWebArchives}"/>
+        <property name="processWebArchives" value="#{${processWebArchives} == null?false : ${processWebArchives}}"/>
         <property name="generateHash" value="${generateHash}"/>
         <property name="hashAlgorithm" value="${hashAlgorithm}"/>
         <property name="matchAllExtensions" value="${matchAllExtensions}"/>


### PR DESCRIPTION
java.net rules for URI parsing enforce restricted characters on querystrings, causing droid to exit in the middle of an ARC file when it met any.