### PR TITLE
[feature] Add SHA-1 to DROID output and documentation.

### DIFF
--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.4</version>
+            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>de.schlichtherle</groupId>

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalConfig.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalConfig.java
@@ -280,6 +280,7 @@ public class DroidGlobalConfig {
         List<String> availableHashAlgorithms = new ArrayList<String>();
 
         availableHashAlgorithms.add("md5");
+        availableHashAlgorithms.add("sha1");
         availableHashAlgorithms.add("sha256");
 
         allSettings.put(AVAILABLE_HASH_ALGORITHMS, availableHashAlgorithms);

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalProperty.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalProperty.java
@@ -107,7 +107,7 @@ public enum DroidGlobalProperty {
     /** Generate hashes for each file analysed?. */
     GENERATE_HASH("profile.generateHash", PropertyType.BOOLEAN, true),
 
-    /** Default hash algorithm to use (currently only md5, sha256 available). */
+    /** Default hash algorithm to use (currently only md5, sha1, sha256 available). */
     HASH_ALGORITHM("profile.hashAlgorithm", PropertyType.TEXT, true),
 
     /** CSV Export one row per format. */

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGenerator.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2012, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package uk.gov.nationalarchives.droid.core.interfaces.hash;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * @author gseaman
+ *
+ */
+public class SHA1HashGenerator implements HashGenerator {
+
+    /**
+     * {@inheritDoc}
+     * @throws java.io.IOException
+     */
+    @Override
+    public String hash(InputStream in) throws IOException {
+        return DigestUtils.sha1Hex(in);
+    }
+
+}

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGeneratorTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGeneratorTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2012, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.gov.nationalarchives.droid.core.interfaces.hash;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author gseaman
+ *
+ */
+public class SHA1HashGeneratorTest {
+
+    private SHA1HashGenerator hashGenerator;
+
+    @Before
+    public void setup() {
+        hashGenerator = new SHA1HashGenerator();
+    }
+
+    @Test
+    public void testGenerateHashFromInputStream() throws IOException {
+
+        InputStream in = getClass().getClassLoader().getResourceAsStream("hash/commons-collections-3.2.1-bin.zip");
+        String hash = hashGenerator.hash(in);
+        assertEquals("a8145a4737bc7dbc192e7ca49d563f598e9e07a4", hash);
+    }
+}

--- a/droid-core-interfaces/src/test/resources/hash/README.txt
+++ b/droid-core-interfaces/src/test/resources/hash/README.txt
@@ -32,5 +32,7 @@
 
 The file commons-collections-3.2.1-bin.zip in this directory has a known MD5 hash of:
  23925dbfaf3c266b487c264c1a643b51
+ Its SHA1 hash is:
+ a8145a4737bc7dbc192e7ca49d563f598e9e07a4
  Its SHA256 hash is:
  759d425105e23ba7016396b7dba776fc14a0e962bcf19a9f2fcf5efa1d23f45b

--- a/droid-help/src/main/resources/Web pages/Change preferences.html
+++ b/droid-help/src/main/resources/Web pages/Change preferences.html
@@ -111,7 +111,7 @@
         <a href="Change preferences.html#AnalyseWebArchive">Analyse contents of web archive files</a>
       </li>
       <li>
-        <a href="Change preferences.html#GenerateHash">Generate MD5 hash for each file</a>
+        <a href="Change preferences.html#GenerateHash">Generate MD5, SHA1, or SHA256 hash for each file</a>
       </li>
       <li>
         <a href="Change preferences.html#MaxBytes">Maximum bytes to scan</a>
@@ -177,7 +177,7 @@
     <p align="left">
        If this option is checked, then DROID will produce a hash (checksum) for the content of the file.
       &nbsp;By default this option is off, as generating hashes slows down profiling significantly.
-      The hash type defaults to MD5, but SHA256 can be selected as an alternative.
+      The hash type defaults to MD5, but SHA1 or SHA256 can be selected as an alternative.
       &nbsp;Read "<a href="Detecting duplicate files.html">Detecting duplicate files</a>" for more
       information on why you may want to generate hashes.
     </p>

--- a/droid-help/src/main/resources/Web pages/Detecting duplicate files.html
+++ b/droid-help/src/main/resources/Web pages/Detecting duplicate files.html
@@ -79,8 +79,8 @@
        One method&nbsp;of duplicate detection is to use content hashes. If two files have the same
       hash value, then they are overwhelmingly likely to have identical content.&nbsp;The odds of
       two arbitrary files having the same hash value by accident are less than 1 in
-      18,000,000,000,000,000,000, which is very, very low (these odds are for MD5, with SHA256 the 
-      odds become orders of magnitude lower still).&nbsp;DROID can generate content hashes
+      18,000,000,000,000,000,000, which is very, very low (these odds are for MD5, with SHA1, and then SHA256 
+      the odds become orders of magnitude lower still).&nbsp;DROID can generate content hashes
       for your files, but note that DROID will not locate files with the same hash value for you,
       only generate them in the first place. &nbsp;If you export your profiles to a CSV file and
       import them into software like Excel or Access, you can query for files which have the same
@@ -137,18 +137,20 @@
       "../Images/Icon_External_Link.png">&nbsp;text, which can be used as a signature to identify
       the content of a file. &nbsp;DROID can generate hashes called "<a href=
       "http://en.wikipedia.org/wiki/MD5">MD5</a>"<img src=
-      "../Images/Icon_External_Link.png">&nbsp; or <a href=
+      "../Images/Icon_External_Link.png">&nbsp;, or <a href=
+      "http://en.wikipedia.org/wiki/SHA-1">SHA1</a>"<img src=
+      "../Images/Icon_External_Link.png">&nbsp;, or <a href=
       "http://en.wikipedia.org/wiki/SHA256">SHA256</a>"<img src=
-      "../Images/Icon_External_Link.png">&nbsp;, which are both fairly fast to produce (relative
+      "../Images/Icon_External_Link.png">&nbsp;, which are fairly fast to produce (relative
       to other hashing algorithms). 
     </p>
     <p>
-       Hashes are useful to locate duplicates in the files you profile,&nbsp;and to match with
-      common files which have published hash values. &nbsp;However, MD5 hashes are not resistant to
+      Hashes are useful to locate duplicates in the files you profile,&nbsp;and to match with
+      common files which have published hash values. However, MD5 hashes are not resistant to
       malicious attack - an attacker can create files which have the same hash but with different
       content. &nbsp;The goal of hashing in DROID&nbsp;is not to provide a cryptographic assurance
       of uniqueness, only to locate likely duplicates and to&nbsp;link to forensic hash databases
-      (most of which use MD5). SHA256 is more recent and more secure than MD5, but should still not be 
+      (most of which use MD5). SHA1 and SHA256 are more recent and more secure than MD5, but should still not be 
       taken to provide an absolute guarantee of uniqueness.
     </p>
     <p>

--- a/droid-help/src/main/resources/Web pages/Exporting profiles.html
+++ b/droid-help/src/main/resources/Web pages/Exporting profiles.html
@@ -252,11 +252,11 @@
       7.
     </p>
     <h3>
-       MD5 or SHA256 hash
+       MD5, SHA1, or SHA256 hash
     </h3>
     <p>
        If you have enabled <a href="Change preferences.html#GenerateHash">hash generation</a> in
-      the preferences, then this column will contain the MD5 or SHA256 hash for each file and archival file
+      the preferences, then this column will contain the MD5, SHA1, or SHA256 hash for each file and archival file
       processed. &nbsp;See "<a href="Detecting duplicate files.html">Detecting duplicate files</a>"
       for more information on hashes.
     </p>

--- a/droid-help/src/main/resources/Web pages/Information collected by DROID.html
+++ b/droid-help/src/main/resources/Web pages/Information collected by DROID.html
@@ -697,7 +697,7 @@
     </table>
     <p>
        DROID can optionally generate a content hash of the contents of each file and archival file,
-      using the industry standard &#39;MD5&#39; or &#39;SHA256&#39; algorithms. A content hash is a short signature&nbsp;that
+      using the industry standard &#39;MD5&#39; &#39;SHA1&#39; or &#39;SHA256&#39; algorithms. A content hash is a short signature&nbsp;that
       can be used to identify the content of the file. It is extremely unlikely that two different
       files will have the same content hash (although this is a remote possibility).&nbsp;&nbsp;
     </p>

--- a/droid-results/src/main/resources/META-INF/spring-results.xml
+++ b/droid-results/src/main/resources/META-INF/spring-results.xml
@@ -274,6 +274,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
    
    <!-- BNO: these changes were made in SHA256 branch but didn't appear to get pulled down from GitHub --> 
  <bean id="md5HashGenerator" class="uk.gov.nationalarchives.droid.core.interfaces.hash.MD5HashGenerator"/>
+ <bean id="sha1HashGenerator" class="uk.gov.nationalarchives.droid.core.interfaces.hash.SHA1HashGenerator"/>
  <bean id="sha256HashGenerator" class="uk.gov.nationalarchives.droid.core.interfaces.hash.SHA256HashGenerator"/>
     
     <bean id="submissionQueue" class="uk.gov.nationalarchives.droid.submitter.JaxBSubmissionQueueDao">


### PR DESCRIPTION
Previously noted as a potential enhancement that will help Archives New Zealand, but also a new requirement gathered at a recent digital preservation knowledge sharing event with State Library New South Wales; the addition of SHA1 to DROID output. 

Code has been contributed following existing TNA guidelines, inferred from  the existing code base. Documentation and comments have been updated to reflect a third hashing algorithm and to ensure that the documentation continues to make sense to users. 

A unit test has been created to test SHA1. The tool has been build and tested on a small corpus of objects to ensure that output is as expected. UI and reporting changes have been reflected as expected on building and usage. 

N.B. Commons-codec has been updated from 1.4 to 1.10 because a number of functions were previously deprecated and didn't include SHA1. Tests continue to pass with increment. 