### PR TITLE
Updated droid.bat and droid.sh file version references from 6.1.5 to …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ jdk:
  - oraclejdk7
 before_install:
  - "sudo apt-get update"
- - "sudo apt-get install oraclejdk7"
 before_script:
  - "export DISPLAY=:99.0"
  - "sh -e /etc/init.d/xvfb start"

--- a/droid-binary/bin/droid.bat
+++ b/droid-binary/bin/droid.bat
@@ -138,13 +138,13 @@ IF "%1"=="" GOTO NOPARAM
 
 :PARAM
 REM has command line parameters passed - run command line version:
-java %DROIDOPTIONS% -jar droid-command-line-6.1.5.jar %*
+java %DROIDOPTIONS% -jar droid-command-line-6.1.6.jar %*
 
 GOTO end
 
 :NOPARAM
 REM no command line parameters passed - run GUI version:
-start javaw %DROIDOPTIONS% -jar droid-ui-6.1.5.jar
+start javaw %DROIDOPTIONS% -jar droid-ui-6.1.6.jar
 
 :END
 

--- a/droid-binary/bin/droid.sh
+++ b/droid-binary/bin/droid.sh
@@ -130,7 +130,7 @@ fi
 
 # Run the command line or user interface version with the options:
 if [ $# -gt 0 ]; then
-    java $OPTIONS -jar droid-command-line-6.1.5.jar "$@"
+    java $OPTIONS -jar droid-command-line-6.1.6.jar "$@"
 else
-    java $OPTIONS -jar droid-ui-6.1.5.jar
+    java $OPTIONS -jar droid-ui-6.1.6.jar
 fi


### PR DESCRIPTION
Fix for issue with web archive (ARC and WARC) file processing when the latest DROID is deployed to a machine with an existing installation.  Also updates the version references in the .bat and .sh files.