### PR TITLE
Blank profile on new signature file.

### DIFF
--- a/droid-binary/bin/droid.bat
+++ b/droid-binary/bin/droid.bat
@@ -138,13 +138,13 @@ IF "%1"=="" GOTO NOPARAM
 
 :PARAM
 REM has command line parameters passed - run command line version:
-java %DROIDOPTIONS% -jar droid-command-line-6.2.jar %*
+java %DROIDOPTIONS% -jar droid-command-line-6.2.1.jar %*
 
 GOTO end
 
 :NOPARAM
 REM no command line parameters passed - run GUI version:
-start javaw %DROIDOPTIONS% -jar droid-ui-6.2.jar
+start javaw %DROIDOPTIONS% -jar droid-ui-6.2.1.jar
 
 :END
 

--- a/droid-binary/bin/droid.sh
+++ b/droid-binary/bin/droid.sh
@@ -130,7 +130,7 @@ fi
 
 # Run the command line or user interface version with the options:
 if [ $# -gt 0 ]; then
-    java $OPTIONS -jar droid-command-line-6.2.jar "$@"
+    java $OPTIONS -jar droid-command-line-6.2.1.jar "$@"
 else
-    java $OPTIONS -jar droid-ui-6.2.jar
+    java $OPTIONS -jar droid-ui-6.2.1.jar
 fi

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -180,7 +180,6 @@ public class NoProfileRunCommand implements DroidCommand {
             RequestIdentifier identifier = new RequestIdentifier(uri);
             identifier.setParentId(1L);
             
-            InputStream in = null;
             IdentificationRequest<File> request = new FileSystemIdentificationRequest(metaData, identifier);
             try {
                 request.open(file);
@@ -194,12 +193,10 @@ public class NoProfileRunCommand implements DroidCommand {
             } catch (IOException e) {
                 throw new CommandExecutionException(e);
             } finally {
-                if (in != null) {
+                if (request != null) {
                     try {
                     	request.close();
                     	file=null;
-                    	in.close();
-                        
                     } catch (IOException e) {
                         throw new CommandExecutionException(e);
                     }


### PR DESCRIPTION
Fixes an issue whereby the first profile run after installing a new signature file (or reverting to an earlier one) is sometimes blank.
