### PR TITLE
Support invoking DROID outside its home directory

### DIFF
--- a/droid-binary/bin/droid.bat
+++ b/droid-binary/bin/droid.bat
@@ -40,7 +40,7 @@ REM =========
 
 REM Default user dir: 
 REM -----------------
-REM This is where droid will place user settings 
+REM This is where DROID will place user settings 
 REM If not set, it will default to a directory called ".droid6"
 REM under the user's home directory.
 REM Also configure this property using the environment variable: droidUserDir
@@ -50,7 +50,7 @@ REM SET droidUser=
 
 REM Default temporary file dir:
 REM ---------------------------
-REM This is where droid will place temporary working files,
+REM This is where DROID will place temporary working files,
 REM including decompressed archival files and working profile databases.
 REM If not set, it will default to the droidUserDir 
 REM (by default, under the user's home directory)
@@ -61,7 +61,7 @@ REM SET droidTemp=
 
 REM Default log dir: 
 REM ----------------
-REM This is where droid will write its log files.
+REM This is where DROID will write its log files.
 REM If not set, it will default to a folder called "logs"
 REM under the droidUserDir.
 REM Also configure this property using the environment variable: droidLogDir
@@ -82,9 +82,9 @@ REM SET log4j=
 REM Default console logging level:
 REM ------------------------------
 REM This allows you to set the default logging level used by
-REM DROID when logging to the command line console.  If not set,
+REM DROID when logging to the command-line console.  If not set,
 REM it defaults to INFO level logging, unless running in quiet
-REM mode from the command-line, in which case the log level is
+REM mode from the command line, in which case the log level is
 REM overridden to be ERROR.
 REM SET logLevel=INFO
 
@@ -100,53 +100,53 @@ REM SET droidMemory=512
 
 REM Assemble options
 REM ================
-REM default to using 512 megabytes of memory if no other settings provided:
-SET DROIDOPTIONS="-Xmx512m"
+REM Default to using 512 megabytes of memory if no other settings provided:
+SET DROID_OPTIONS="-Xmx512m"
 
 IF "%droidMemory%"=="" GOTO UserDir
-SET DROIDOPTIONS="-Xmx%droidMemory%m"
+SET DROID_OPTIONS="-Xmx%droidMemory%m"
 
 :UserDir
 IF "%droidUser%"=="" GOTO TempDir
-SET DROIDOPTIONS=%DROIDOPTIONS% "-DdroidUserDir=%droidUser%"
+SET DROID_OPTIONS=%DROID_OPTIONS% "-DdroidUserDir=%droidUser%"
 
 :TempDir
 IF "%droidTemp%"=="" GOTO LogOptions
-SET DROIDOPTIONS=%DROIDOPTIONS% "-DdroidTempDir=%droidTemp%"
+SET DROID_OPTIONS=%DROID_OPTIONS% "-DdroidTempDir=%droidTemp%"
 
 :LogOptions
 IF "%droidLog%"=="" GOTO Log4JConfig
-SET DROIDOPTIONS=%DROIDOPTIONS% "-DdroidLogDir=%droidLog%"
+SET DROID_OPTIONS=%DROID_OPTIONS% "-DdroidLogDir=%droidLog%"
 
 :Log4JConfig
 IF "%log4j%"=="" GOTO LogLevel
-SET DROIDOPTIONS=%DROIDOPTIONS% "-Dlog4j.configuration=%log4j%"
+SET DROID_OPTIONS=%DROID_OPTIONS% "-Dlog4j.configuration=%log4j%"
 
 :LogLevel
 IF "%logLevel%"=="" GOTO RunDROID
-SET DROIDOPTIONS=%DROIDOPTIONS% "-DconsoleLogThreshold=%logLevel%"
+SET DROID_OPTIONS=%DROID_OPTIONS% "-DconsoleLogThreshold=%logLevel%"
 
 
 REM Run DROID:
 REM ==========
 :RunDROID
 
-REM ECHO Running DROID with the following options: %DROIDOPTIONS%
+REM Infer DROID_HOME from script location
+SET DROID_HOME=%~dp0
 
-REM Choose whether to run the command line or gui version of DROID:
+REM ECHO Running DROID with the following options: %DROID_OPTIONS%
+
+REM Choose whether to run the command-line or GUI version of DROID:
 IF "%1"=="" GOTO NOPARAM
 
 :PARAM
-REM has command line parameters passed - run command line version:
-java %DROIDOPTIONS% -jar droid-command-line-6.3.jar %*
+REM Has command-line parameters -- run command-line version:
+java %DROID_OPTIONS% -jar "%DROID_HOME%droid-command-line-6.3.jar" %*
 
 GOTO end
 
 :NOPARAM
-REM no command line parameters passed - run GUI version:
-start javaw %DROIDOPTIONS% -jar droid-ui-6.3.jar
+REM No command-line parameters passed -- run GUI version:
+start javaw %DROID_OPTIONS% -jar "%DROID_HOME%droid-ui-6.3.jar"
 
 :END
-
-
-

--- a/droid-binary/bin/droid.sh
+++ b/droid-binary/bin/droid.sh
@@ -40,7 +40,7 @@
 
 # Default work dir: droidUserDir
 # ------------------------------
-# This is where droid will place user settings
+# This is where DROID will place user settings
 # If not set, it will default to a directory called ".droid6" 
 # under the user's home directory.
 # It can be configured using this property, or by an environment
@@ -49,7 +49,7 @@ droidUserDir=""
 
 # Default work dir: droidTempDir
 # ------------------------------
-# This is where droid will create temporary files.
+# This is where DROID will create temporary files.
 # If not set, it will default to a directory called "tmp" 
 # under the droid user directory.
 # It can be configured using this property, or by an environment
@@ -58,13 +58,12 @@ droidTempDir=""
 
 # Default log dir: droidLogDir
 # ----------------------------
-# This is where droid will write its log files.
+# This is where DROID will write its log files.
 # If not set, it will default to a folder called "logs"
 # under the droidWorkDir.
 # It can be configured using this property, or by an environment
 # variable of the same name.
 droidLogDir=""
-
 
 # Log configuration: log4j
 # ------------------------
@@ -74,7 +73,6 @@ droidLogDir=""
 # It can be configured using this setting, or by an environment
 # variable called log4j.configuration
 log4j=""
-
 
 # Default console logging level
 # -----------------------------
@@ -91,22 +89,40 @@ logLevel=""
 droidMemory="512m"
 
 
-
 # Run DROID:
 # ==========
+
+# Infer DROID_HOME from script location
+SCRIPT=$0
+
+# Resolve absolute and relative symlinks
+while [ -h "$SCRIPT" ]; do
+    LS=$( ls -ld "$SCRIPT" )
+    LINK=$( expr "$LS" : '.*-> \(.*\)$' )
+    if expr "$LINK" : '/.*' > /dev/null; then
+        SCRIPT="$LINK"
+    else
+        SCRIPT="$( dirname "$SCRIPT" )/$LINK"
+    fi
+done
+
+# Store absolute location
+CWD=$( pwd )
+DROID_HOME="$( cd "$(dirname "$SCRIPT" )" && pwd )"
+cd "$CWD"
 
 # Collect settings into runtime options for droid:
 OPTIONS=""
 
-# Detect if we are running on a mac or not:
-os=`uname`
-if [ "Darwin" = "$os" ]; then
+# Detect if we are running on a Mac:
+OS=$( uname )
+if [ "Darwin" = "$OS" ]; then
     OPTIONS=$OPTIONS" -Xdock:name=DROID"
     OPTIONS=$OPTIONS" -Dcom.apple.mrj.application.growbox.intrudes=false"
     OPTIONS=$OPTIONS" -Dcom.apple.mrj.application.live-resize=true"
 fi
 
-# Build command line options from the settings above:
+# Build command-line options from the settings above:
 if [ -n "$droidMemory" ]; then
     OPTIONS=$OPTIONS" -Xmx$droidMemory"
 fi
@@ -128,9 +144,9 @@ fi
 
 # echo "Running DROID with these options: $OPTIONS $@"
 
-# Run the command line or user interface version with the options:
+# Run the command-line or user interface version with the options:
 if [ $# -gt 0 ]; then
-    java $OPTIONS -jar droid-command-line-6.3.jar "$@"
+    java $OPTIONS -jar "$DROID_HOME/droid-command-line-6.3.jar" "$@"
 else
-    java $OPTIONS -jar droid-ui-6.3.jar
+    java $OPTIONS -jar "$DROID_HOME/droid-ui-6.3.jar"
 fi


### PR DESCRIPTION
This change updates the Windows and Unix scripts to allow them to be invoked from outside their installation directory or through symbolic links, and guards against paths which include spaces.

Tested on MacOS 10.12, MinGW64, and Windows 10.