### PR TITLE
Build on precise (ubuntu 12.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: java
 jdk:
  - oraclejdk7


### PR DESCRIPTION
Trusty(14.04) don't support oracle java7.
https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming