### PR TITLE
Move droid to Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: java
 jdk:
- - openjdk7
  - openjdk8
  - oraclejdk8
 before_script:

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -74,15 +74,15 @@
     </mailingLists>
   
     <properties>
-        <project.build.source>1.7</project.build.source>
-        <project.build.target>1.7</project.build.target>
+        <project.build.source>1.8</project.build.source>
+        <project.build.target>1.8</project.build.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <project.email>pronom@nationalarchives.gsi.gov.uk</project.email>
 
-        <spring.version>4.3.11.RELEASE</spring.version>
+        <spring.version>5.0.0.RELEASE</spring.version>
         <hibernate.version>5.4.1.Final</hibernate.version>
-        <derby.version>10.12.1.1</derby.version> <!-- TODO derby >10.13 requires Java 8 -->
+        <derby.version>10.13.1.1</derby.version>
         <cxf.version>2.3.1</cxf.version>
         <aspectj.version>1.8.11</aspectj.version>
         <java.iso-tools.version>2.0.1</java.iso-tools.version>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -133,6 +133,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-jcl</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/planet/xml/dao/JpaPlanetsXMLDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/planet/xml/dao/JpaPlanetsXMLDaoTest.java
@@ -50,14 +50,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionFieldEnum;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionOperator;
@@ -72,7 +71,7 @@ import uk.gov.nationalarchives.droid.profile.FilterImpl;
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml",
         "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = false)
+@Commit
 public class JpaPlanetsXMLDaoTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileDaoTest.java
@@ -49,14 +49,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 
 
 /**
@@ -66,7 +65,7 @@ import org.springframework.test.context.transaction.TransactionConfiguration;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = true)
+@Commit
 public class JpaProfileDaoTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileFilterTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileFilterTest.java
@@ -49,14 +49,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionFieldEnum;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionOperator;
@@ -69,7 +68,7 @@ import uk.gov.nationalarchives.droid.core.interfaces.filter.FilterValue;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = true)
+@Commit
 public class JpaProfileFilterTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNodePersistenceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNodePersistenceTest.java
@@ -38,12 +38,10 @@ import org.dbunit.database.IDatabaseConnection;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -56,7 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 //@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml", 
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = true)
+@Commit
 @Transactional
 @Ignore
 public class ProfileResourceNodePersistenceTest {

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
@@ -55,9 +55,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -74,7 +74,7 @@ import javax.sql.DataSource;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = true)
+@Commit
 public class JpaReportDaoTest {
 
     private static IDataSet testData;


### PR DESCRIPTION
This PR moves DROID to require Java 8 as a minimum. It also updates DROID to Spring 5; which is a pre-requisite to enabling support for Java 9 platforms.