### PR TITLE
Add support for Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: java
 jdk:
- - openjdk7
  - openjdk8
  - oraclejdk8
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: java
 jdk:
  - openjdk8
  - oraclejdk8
+ - oraclejdk9
 before_script:
  - "export DISPLAY=:99.0"
  - "sh -e /etc/init.d/xvfb start"

--- a/droid-binary/bin/droid.bat
+++ b/droid-binary/bin/droid.bat
@@ -141,12 +141,12 @@ IF "%1"=="" GOTO NOPARAM
 
 :PARAM
 REM Has command-line parameters -- run command-line version:
-java %DROID_OPTIONS% -jar "%DROID_HOME%droid-command-line-${project.version}.jar" %*
+java -XX:+IgnoreUnrecognizedVMOptions --add-modules=java.xml.bind,java.xml.ws,java.xml.ws.annotation %DROID_OPTIONS% -jar "%DROID_HOME%droid-command-line-${project.version}.jar" %*
 
 GOTO end
 
 :NOPARAM
 REM No command-line parameters passed -- run GUI version:
-start javaw %DROID_OPTIONS% -jar "%DROID_HOME%droid-ui-${project.version}.jar"
+start javaw -XX:+IgnoreUnrecognizedVMOptions --add-modules=java.xml.bind,java.xml.ws,java.xml.ws.annotation %DROID_OPTIONS% -jar "%DROID_HOME%droid-ui-${project.version}.jar"
 
 :END

--- a/droid-binary/bin/droid.sh
+++ b/droid-binary/bin/droid.sh
@@ -146,7 +146,7 @@ fi
 
 # Run the command-line or user interface version with the options:
 if [ $# -gt 0 ]; then
-    java $OPTIONS -jar "$DROID_HOME/droid-command-line-${project.version}.jar" "$@"
+    java -XX:+IgnoreUnrecognizedVMOptions --add-modules=java.xml.bind,java.xml.ws,java.xml.ws.annotation $OPTIONS -jar "$DROID_HOME/droid-command-line-${project.version}.jar" "$@"
 else
-    java $OPTIONS -jar "$DROID_HOME/droid-ui-${project.version}.jar"
+    java -XX:+IgnoreUnrecognizedVMOptions --add-modules=java.xml.bind,java.xml.ws,java.xml.ws.annotation $OPTIONS -jar "$DROID_HOME/droid-ui-${project.version}.jar"
 fi

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -74,15 +74,15 @@
     </mailingLists>
   
     <properties>
-        <project.build.source>1.7</project.build.source>
-        <project.build.target>1.7</project.build.target>
+        <project.build.source>1.8</project.build.source>
+        <project.build.target>1.8</project.build.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <project.email>pronom@nationalarchives.gsi.gov.uk</project.email>
 
-        <spring.version>4.3.11.RELEASE</spring.version>
+        <spring.version>5.0.0.RELEASE</spring.version>
         <hibernate.version>5.4.1.Final</hibernate.version>
-        <derby.version>10.12.1.1</derby.version> <!-- TODO derby >10.13 requires Java 8 -->
+        <derby.version>10.13.1.1</derby.version>
         <cxf.version>2.3.1</cxf.version>
         <aspectj.version>1.8.11</aspectj.version>
         <java.iso-tools.version>2.0.1</java.iso-tools.version>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -83,7 +83,7 @@
         <spring.version>5.0.0.RELEASE</spring.version>
         <hibernate.version>5.4.1.Final</hibernate.version>
         <derby.version>10.13.1.1</derby.version>
-        <cxf.version>2.3.1</cxf.version>
+        <cxf.version>3.2.0</cxf.version>
         <aspectj.version>1.8.11</aspectj.version>
         <java.iso-tools.version>2.0.1</java.iso-tools.version>
         <flying-saucer.version>9.1.7</flying-saucer.version>
@@ -139,6 +139,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.20</version>
+                    <configuration>
+                        <!-- enable modules on Java 9, ignore on previous VMs -->
+                        <argLine>-XX:+IgnoreUnrecognizedVMOptions --add-modules=java.xml.bind,java.xml.ws,java.xml.ws.annotation</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -72,7 +72,7 @@
 								<ignoredUnusedDeclaredDependency>javax.transaction:jta:jar:${jta.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.aspectj:aspectjweaver:jar:${aspectj.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>cglib:cglib-nodep:jar:${cglib.version}</ignoredUnusedDeclaredDependency>
-								<ignoredUnusedDeclaredDependency>org.apache.cxf:cxf-rt-bindings-http:jar:${cxf.version}</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.apache.cxf:cxf-rt-frontend-jaxws:jar:${cxf.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.apache.cxf:cxf-rt-bindings-soap:jar:${cxf.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12:jar:${slf4j.version}</ignoredUnusedDeclaredDependency>
 							</ignoredUnusedDeclaredDependencies>
@@ -194,7 +194,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
-			<artifactId>cxf-rt-bindings-http</artifactId>
+			<artifactId>cxf-rt-frontend-jaxws</artifactId>
 			<version>${cxf.version}</version>
 			<scope>runtime</scope>
 		</dependency>
@@ -205,7 +205,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
-			<artifactId>cxf-api</artifactId>
+			<artifactId>cxf-core</artifactId>
 			<version>${cxf.version}</version>
 		</dependency>
 		<dependency>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -133,6 +133,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-jcl</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/PronomSignatureService.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/PronomSignatureService.java
@@ -47,7 +47,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.transport.http.HTTPConduit;
-import org.apache.cxf.transports.http.configuration.ClientCacheControlType;
 import org.apache.cxf.transports.http.configuration.ConnectionType;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.cxf.transports.http.configuration.ProxyServerType;
@@ -171,7 +170,7 @@ public class PronomSignatureService implements SignatureUpdateService {
         HTTPClientPolicy httpClientPolicy = new HTTPClientPolicy();
         httpClientPolicy.setConnection(ConnectionType.CLOSE);
         httpClientPolicy.setAllowChunking(true);
-        httpClientPolicy.setCacheControl(ClientCacheControlType.NO_CACHE);
+        httpClientPolicy.setCacheControl("no-cache");
         
         if (proxySettings.isEnabled()) {
             httpClientPolicy.setProxyServer(proxySettings.getProxyHost());
@@ -179,7 +178,7 @@ public class PronomSignatureService implements SignatureUpdateService {
             httpClientPolicy.setProxyServerType(ProxyServerType.HTTP);
         } else {
             httpClientPolicy.setProxyServer(null);
-            httpClientPolicy.unsetProxyServerPort();
+            httpClientPolicy.setProxyServerPort(null);
             httpClientPolicy.setProxyServerType(null);
         }
         

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/planet/xml/dao/JpaPlanetsXMLDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/planet/xml/dao/JpaPlanetsXMLDaoTest.java
@@ -50,14 +50,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionFieldEnum;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionOperator;
@@ -72,7 +71,7 @@ import uk.gov.nationalarchives.droid.profile.FilterImpl;
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml",
         "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = false)
+@Commit
 public class JpaPlanetsXMLDaoTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileDaoTest.java
@@ -49,14 +49,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 
 
 /**
@@ -66,7 +65,7 @@ import org.springframework.test.context.transaction.TransactionConfiguration;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = true)
+@Commit
 public class JpaProfileDaoTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileFilterTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileFilterTest.java
@@ -49,14 +49,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionFieldEnum;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionOperator;
@@ -69,7 +68,7 @@ import uk.gov.nationalarchives.droid.core.interfaces.filter.FilterValue;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = true)
+@Commit
 public class JpaProfileFilterTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNodePersistenceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNodePersistenceTest.java
@@ -38,12 +38,10 @@ import org.dbunit.database.IDatabaseConnection;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -56,7 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 //@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml", 
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = true)
+@Commit
 @Transactional
 @Ignore
 public class ProfileResourceNodePersistenceTest {

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
@@ -55,9 +55,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -74,7 +74,7 @@ import javax.sql.DataSource;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@TransactionConfiguration(defaultRollback = true)
+@Commit
 public class JpaReportDaoTest {
 
     private static IDataSet testData;

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
@@ -79,6 +79,7 @@ import javax.swing.table.TableRowSorter;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
@@ -292,10 +293,10 @@ public class ResourceSelectorDialog extends JDialog {
         File f = (File) table.getValueAt(rowIndex, 0);
         if (f.isDirectory()) {
             final TreePath selectionPath = tree.getSelectionPath();
-            DefaultMutableTreeNode treeNode = (DefaultMutableTreeNode) 
+            DefaultMutableTreeNode treeNode = (DefaultMutableTreeNode)
                 selectionPath.getLastPathComponent();
-            for (Enumeration<DefaultMutableTreeNode> e = treeNode.children(); e.hasMoreElements();) {
-                DefaultMutableTreeNode n = e.nextElement();
+            for (Enumeration<TreeNode> e = treeNode.children(); e.hasMoreElements();) {
+                DefaultMutableTreeNode n = (DefaultMutableTreeNode) e.nextElement();
                 if (n.getUserObject().equals(f)) {
                     final TreePath path = new TreePath(n.getPath());
                     tree.expandPath(path);

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ExpandingTreeListener.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ExpandingTreeListener.java
@@ -38,6 +38,7 @@ import java.util.List;
 import javax.swing.event.TreeExpansionEvent;
 import javax.swing.event.TreeWillExpandListener;
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import uk.gov.nationalarchives.droid.gui.ProfileForm;
 import uk.gov.nationalarchives.droid.profile.ProfileManager;
@@ -105,8 +106,8 @@ public class ExpandingTreeListener implements TreeWillExpandListener {
         ProfileResourceNode prn = (ProfileResourceNode) collapsingNode.getUserObject();
         profileForm.getInMemoryNodes().remove(prn.getId());
         
-        for (Enumeration<DefaultMutableTreeNode> e = collapsingNode.children(); e.hasMoreElements();) {
-            DefaultMutableTreeNode nodeToRemove = e.nextElement();
+        for (Enumeration<TreeNode> e = collapsingNode.children(); e.hasMoreElements();) {
+            DefaultMutableTreeNode nodeToRemove = (DefaultMutableTreeNode) e.nextElement();
             final ProfileResourceNode node = (ProfileResourceNode) nodeToRemove.getUserObject();
             profileForm.getInMemoryNodes().remove(node.getId());
         }

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/worker/DroidJob.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/worker/DroidJob.java
@@ -42,6 +42,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingWorker;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -89,9 +90,9 @@ public class DroidJob extends SwingWorker<Integer, ProfileResourceNode> {
             if (parent != null) {
                 parent.setAllowsChildren(true);
                 boolean updated = false;
-                for (Enumeration<DefaultMutableTreeNode> e = parent.children(); 
-                    e.hasMoreElements() && !updated;) {
-                    DefaultMutableTreeNode childNode = e.nextElement();
+                for (Enumeration<TreeNode> e = parent.children();
+                     e.hasMoreElements() && !updated;) {
+                    DefaultMutableTreeNode childNode = (DefaultMutableTreeNode) e.nextElement();
                     if (childNode.getUserObject().equals(node)) {
                         childNode.setUserObject(node);
                         childNode.setAllowsChildren(node.allowsChildren());


### PR DESCRIPTION
Closes https://github.com/digital-preservation/droid/issues/186

This PR builds atop PRs:
1. https://github.com/digital-preservation/droid/pull/187

and adds support for running DROID on Java 9 JVM's, whilst still only requiring Java 8 as a minimum.
Best bet would be to merge https://github.com/digital-preservation/droid/pull/187 first.