### PR TITLE
Adds support for Appveyor CI which runs on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ DROID (Digital Record Object Identification)
 =====
 The latest binary file can be downloaded from [The National Archives website](http://www.nationalarchives.gov.uk/information-management/projects-and-work/droid.htm "The National Archives website").
 
-[![Build Status](https://secure.travis-ci.org/digital-preservation/droid.png)](http://travis-ci.org/digital-preservation/droid)
+[![Build Status](https://secure.travis-ci.org/digital-preservation/droid.png)](http://travis-ci.org/digital-preservation/droid) [![Build status](https://ci.appveyor.com/api/projects/status/hrr6c3ckbghjvd7h/branch/master?svg=true)](https://ci.appveyor.com/project/AdamRetter/droid/branch/master)
 
 More information can be found on the DROID github pages here: http://digital-preservation.github.com/droid/
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+version: '{build}'
+build_script:
+- cmd: mvn compile
+test_script:
+- cmd: mvn test -B

--- a/droid-build-tools/src/main/resources/checkstyle-main.xml
+++ b/droid-build-tools/src/main/resources/checkstyle-main.xml
@@ -237,6 +237,7 @@
 
   <module name="NewlineAtEndOfFile">
     <property name="fileExtensions" value="java, xml"/>
+    <property name="lineSeparator" value="lf"/>  <!-- we always expect Unix like EOF -->
   </module>
 
   <module name="SuppressionCommentFilter">

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -113,7 +113,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.17</version> <!-- >= 2.12 would get rid of the erroneous LICENSE.txt stack dumps in debug -->
+                    <version>2.17</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
 I am hoping that by adding support for the AppVeyor CI (which runs on Microsoft Windows), this will help us ensure that DROID continues to work on both Linux and Windows in future.