### PR TITLE
Cleanup build.

### DIFF
--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -234,7 +234,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>1.4.5</version>
+                <version>3.1.2</version>
                 <configuration>
                     <failBuildOnCVSS>8</failBuildOnCVSS>
                 </configuration>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -28,6 +28,44 @@
 
 	<build>
 		<plugins>
+
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.0.2</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/droid-test-db</outputDirectory>
+							<resources>
+								<resource>
+									<directory>droid-test-db</directory>
+									<filtering>false</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemProperties>
+						<property>
+							<name>derby.stream.error.file</name>
+							<value>${basedir}/target/derby.log</value>
+						</property>
+					</systemProperties>
+				</configuration>
+			</plugin>
+
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
@@ -337,7 +337,7 @@ public class JpaReportDaoTest {
                 try {
 
                     Properties prop = new Properties();
-                    in = JpaReportDaoTest.class.getResourceAsStream("../../../../../../src/test/resources/jpa-test.properties");
+                    in = JpaReportDaoTest.class.getResourceAsStream("/jpa-test.properties");
 
                     prop.load(in);
                     config.setDriverClassName(prop.getProperty("datasource.driverClassName"));
@@ -345,13 +345,6 @@ public class JpaReportDaoTest {
                     config.setUsername(prop.getProperty("datasource.username"));
                     config.setPassword(prop.getProperty("datasource.password"));
                     config.setMaximumPoolSize(Integer.parseInt(prop.getProperty("datasource.maxActive")));
-                //Properties may not be accessible when running the  test from e.g. a Maven bukld via cmmand line
-                } catch (NullPointerException e) {
-                    config.setDriverClassName("org.apache.derby.jdbc.EmbeddedDriver");
-                    config.setJdbcUrl("jdbc:derby:droid-test-db;create=true");
-                    config.setUsername("droid_user");
-                    config.setPassword("droid_user");
-                    config.setMaximumPoolSize(20);
                 } catch(IOException e) {
                     e.printStackTrace();
                 } finally {

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/signature/PronomSignatureServiceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/signature/PronomSignatureServiceTest.java
@@ -83,10 +83,10 @@ public class PronomSignatureServiceTest {
     @Before
     public void setup() throws Exception {
 
-        sigFileDir = Paths.get("tmp_sig_files");
+        sigFileDir = Paths.get("target/tmp_sig_files");
         FileUtil.deleteQuietly(sigFileDir);
         FileUtil.mkdirsQuietly(sigFileDir);
-        Files.deleteIfExists(Paths.get("tmp_sig_files/DROID_SignatureFile_V26.xml"));
+        Files.deleteIfExists(Paths.get("target/tmp_sig_files/DROID_SignatureFile_V26.xml"));
         importer.setEndpointUrl(ENDPOINT_URL);
         ProxySettings proxySettings = new ProxySettings();
         proxySettings.setEnabled(false);

--- a/droid-results/src/test/resources/jpa-test.properties
+++ b/droid-results/src/test/resources/jpa-test.properties
@@ -31,7 +31,7 @@
 #
 
 datasource.driverClassName=org.apache.derby.jdbc.EmbeddedDriver
-datasource.url=jdbc:derby:droid-test-db;create=true
+datasource.url=jdbc:derby:target/droid-test-db;create=true
 datasource.username=droid_user
 datasource.password=droid_user
 datasource.maxActive=20


### PR DESCRIPTION
Remove direct derby-db data files modification. Instead copy database files to target directory and run all queries on data files in target directory.