### PR TITLE
Fixes broken test when built on non-english locale

### DIFF
--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/util/FileUtilTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/util/FileUtilTest.java
@@ -32,6 +32,7 @@
 package uk.gov.nationalarchives.droid.util;
 
 import static org.junit.Assert.assertEquals;
+import java.text.DecimalFormatSymbols;
 
 import org.junit.Test;
 
@@ -43,17 +44,18 @@ public class FileUtilTest {
 
     @Test
     public void testFormatFileSize() {
-        
+
         final long kb12 = 12L * 1024L;
         final long mb12 = 12L * 1000L * 1024L;
         final long gb12 = 12L * 1024L * 1024L * 1024L;
         final long tb12 = 12L * 1024L * 1024L * 1024L * 1024L;
-        
-        
+
+        DecimalFormatSymbols dfs = new DecimalFormatSymbols();
+
         assertEquals("12 bytes", FileUtil.formatFileSize(12L, 3));
         assertEquals("12 KB", FileUtil.formatFileSize(kb12, 3));
-        assertEquals("11.7 MB", FileUtil.formatFileSize(mb12, 1));
+        assertEquals("11"+dfs.getDecimalSeparator()+"7 MB", FileUtil.formatFileSize(mb12, 1));
         assertEquals("12 GB", FileUtil.formatFileSize(gb12, 3));
-        assertEquals("12,288 GB", FileUtil.formatFileSize(tb12, 3));
+        assertEquals("12"+dfs.getGroupingSeparator()+"288 GB", FileUtil.formatFileSize(tb12, 3));
     }
 }


### PR DESCRIPTION
FileUtilTest tests the output of FileUtil.formatFileSize() (which
depends on the locale of the machine the test is run on) against a
literal string (which does not depend on the locale).

This will fail on non-english locales. This fix uses the decimal
separator and grouping separator of the machine running the test and
should make the test independent of the locale it is executed on.

This PR is the exact solution already pointed out in the comments of
#197 

Fixes #197 and #198.