### PR TITLE
shifting support forward to Java 11 and fix/update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - jdk: openjdk10
     - jdk: openjdk11
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode10.1
       env: JAVA_HOME=$(/usr/libexec/java_home)
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       env: JAVA_HOME=$(/usr/libexec/java_home)
+    - dist: bionic
 
 services:
   - xvfb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,10 @@
 version: '{build}'
+install:
+  - cmd: SET JDK_HOME=C:\Program Files\Java\jdk11
+  - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk11
+  - cmd: SET PATH=%JDK_HOME%\bin;%PATH%
+  - cmd: mvn --version
+  - cmd: java -version
 build_script:
 - cmd: mvn compile
 test_script:

--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -212,7 +212,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -104,6 +104,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.shared</groupId>
+                            <artifactId>maven-dependency-analyzer</artifactId>
+                            <version>1.11.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -588,9 +588,9 @@ Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="${project.organ
                 <version>1.8.3</version>
             </dependency>
             <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.2</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-configuration</groupId>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -93,7 +93,7 @@
         <flying-saucer.version>9.1.18</flying-saucer.version>
         <truezip.version>7.7.10</truezip.version>
         <jwat.version>1.1.1</jwat.version>
-        <hamcrest.version>1.3</hamcrest.version>
+        <hamcrest.version>2.1</hamcrest.version>
         <slf4j.version>1.7.28</slf4j.version>
     </properties>
   
@@ -675,7 +675,7 @@ Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="${project.organ
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
             </dependency>
             <dependency>
                 <groupId>xmlunit</groupId>
@@ -710,7 +710,7 @@ Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="${project.organ
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
+                <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
             </dependency>
             <dependency>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -514,7 +514,7 @@ Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="${project.organ
             <dependency>
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-ri</artifactId>
-                <version>2.3.0</version>
+                <version>2.3.2</version>
                 <type>pom</type>
             </dependency>
             <dependency>
@@ -635,7 +635,7 @@ Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="${project.organ
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.10.3</version>
+                <version>2.10.4</version>
             </dependency>
             <dependency>
                 <groupId>org.jwat</groupId>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -22,7 +22,7 @@
 
 	<properties>
 		<jta.version>1.1</jta.version>
-		<cglib.version>3.2.5</cglib.version>
+		<cglib.version>3.3.0</cglib.version>
 		<slf4j.version>1.7.25</slf4j.version>
 	</properties>
 

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -306,8 +306,8 @@
 			<artifactId>commons-configuration</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-collections</groupId>
-			<artifactId>commons-collections</artifactId>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.zaxxer</groupId>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -335,7 +335,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
+			<artifactId>hamcrest</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -117,6 +117,9 @@
 								<ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>com.sun.activation:javax.activation</ignoredUnusedDeclaredDependency>
 							</ignoredUnusedDeclaredDependencies>
+							<ignoredUsedUndeclaredDependencies>
+								<ignoredUsedUndeclaredDependency>stax:stax-api</ignoredUsedUndeclaredDependency>
+							</ignoredUsedUndeclaredDependencies>
 						</configuration>
 					</execution>
 				</executions>

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterPredicate.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterPredicate.java
@@ -31,7 +31,8 @@
  */
 package uk.gov.nationalarchives.droid.profile;
 
-import org.apache.commons.collections.Predicate;
+
+import org.apache.commons.collections4.Predicate;
 
 /**
  * @author Alok Kumar Dash.

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileContextLocator.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileContextLocator.java
@@ -38,8 +38,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.collections.Transformer;
-import org.apache.commons.collections.map.LazyMap;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.map.LazyMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,7 +72,7 @@ public class ProfileContextLocator {
 
     @SuppressWarnings("unchecked")
     private Map<String, ProfileInstance> profileInstances = 
-        LazyMap.decorate(new HashMap<String, ProfileInstance>(), new ProfileTransformer());
+        LazyMap.lazyMap(new HashMap<String, ProfileInstance>(), new ProfileTransformer());
     
     private ProfileInstanceLocator profileInstanceLocator;
     

--- a/droid-swing-ui/pom.xml
+++ b/droid-swing-ui/pom.xml
@@ -181,8 +181,8 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>

--- a/droid-swing-ui/pom.xml
+++ b/droid-swing-ui/pom.xml
@@ -158,14 +158,14 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>uk.gov.nationalarchives.thirdparty.netbeans</groupId>
+            <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-util</artifactId>
-            <version>7.2</version>
+            <version>RELEASE111</version>
         </dependency>
         <dependency>
-            <groupId>uk.gov.nationalarchives.thirdparty.netbeans</groupId>
+            <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-swing-outline</artifactId>
-            <version>7.2</version>
+            <version>RELEASE111</version>
         </dependency>
         <dependency>
             <groupId>org.jdesktop</groupId>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
@@ -66,7 +66,7 @@ import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.text.DefaultFormatterFactory;
 import javax.swing.text.NumberFormatter;
 
-import org.apache.commons.collections.list.SetUniqueList;
+import org.apache.commons.collections4.list.SetUniqueList;
 import org.jdesktop.beansbinding.BeanProperty;
 import org.jdesktop.beansbinding.Binding;
 import org.jdesktop.beansbinding.BindingGroup;
@@ -108,13 +108,13 @@ public class ConfigDialog extends JDialog {
     private ObservableMap<String, Object> globalConfig = ObservableCollections.observableMap(props);
     
     private ObservableList<String> allHashAlgorithms = 
-        ObservableCollections.observableList(SetUniqueList.decorate(new ArrayList()));
+        ObservableCollections.observableList(SetUniqueList.setUniqueList(new ArrayList()));
     
     private ObservableList<String> allBinarySigFiles = 
-        ObservableCollections.observableList(SetUniqueList.decorate(new ArrayList()));
+        ObservableCollections.observableList(SetUniqueList.setUniqueList(new ArrayList()));
     
     private ObservableList<String> allContainerSigFiles = 
-        ObservableCollections.observableList(SetUniqueList.decorate(new ArrayList()));
+        ObservableCollections.observableList(SetUniqueList.setUniqueList(new ArrayList()));
 
     /*
     private ObservableList<String> allTextSigFiles = 


### PR DESCRIPTION
- fixed dependency org-openide-util that prevented to use openJdk11 and used official repository rather than outdated TNA third party repository
- set default java version from 1.8 to 11 (most of the work had been done by Radek)
- did a series of non-breaking updates (or requiring small changes) on dependencies, using github dependabot and maven dependency tool

Update 10/10:
won't change default version to Java 11, still keep compatible with jdk 8 to 11 and updated dependencies