### PR TITLE
fix: NPE on export when extension mismatch filters turned on 

### DIFF
--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/JDBCSqlItemReader.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/JDBCSqlItemReader.java
@@ -338,6 +338,9 @@ public class JDBCSqlItemReader<T> implements ItemReader<T> {
                         case Integer:
                             this.profileStatement.setInt(++i, (Integer) value2);
                             break;
+                        case Boolean:
+                            this.profileStatement.setBoolean(++i, (Boolean) value2);
+                            break;
                         default:
                             log.error("Invalid filter parameter type in JDBCSQLItemReader");
                             break;


### PR DESCRIPTION
fix Null Pointer exception when exporting profile with extension mismatch filters turned on 
https://github.com/digital-preservation/droid/issues/231
