### PR TITLE
Fix display jdk 11

### DIFF
--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.form
@@ -492,8 +492,8 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <Component id="droidToolBar" min="-2" pref="56" max="-2" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Component id="droidToolBar" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="jProfilesTabbedPane" pref="499" max="32767" attributes="0"/>
           </Group>
       </Group>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
@@ -965,7 +965,7 @@ public class DroidMainFrame extends JFrame {
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addComponent(droidToolBar, javax.swing.GroupLayout.PREFERRED_SIZE, 56, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(droidToolBar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jProfilesTabbedPane, javax.swing.GroupLayout.DEFAULT_SIZE, 499, Short.MAX_VALUE))
         );

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.form
@@ -227,10 +227,10 @@
             </DimensionLayout>
             <DimensionLayout dim="1">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" attributes="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="throttleSlider" min="-2" max="-2" attributes="0"/>
-                          <Group type="102" alignment="0" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
+                      <Group type="103" groupAlignment="1" max="-2" attributes="0">
+                          <Component id="throttleSlider" alignment="0" pref="0" max="-2" attributes="0"/>
+                          <Group type="102" attributes="0">
                               <EmptySpace max="-2" attributes="0"/>
                               <Component id="throttleLabel" min="-2" max="-2" attributes="0"/>
                           </Group>
@@ -243,8 +243,12 @@
           <SubComponents>
             <Component class="javax.swing.JSlider" name="throttleSlider">
               <Properties>
+                <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                  <Color blue="f7" green="f6" red="f5" type="rgb"/>
+                </Property>
                 <Property name="maximum" type="int" value="1000"/>
                 <Property name="minorTickSpacing" type="int" value="100"/>
+                <Property name="paintLabels" type="boolean" value="true"/>
                 <Property name="paintTicks" type="boolean" value="true"/>
                 <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                   <ResourceString bundle="uk/gov/nationalarchives/droid/gui/Bundle.properties" key="ProfileForm.throttleSlider.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.java
@@ -356,8 +356,10 @@ public class ProfileForm extends JPanel {
 
         throttlePanel.setVisible(false);
 
+        throttleSlider.setForeground(new java.awt.Color(245, 246, 247));
         throttleSlider.setMaximum(1000);
         throttleSlider.setMinorTickSpacing(100);
+        throttleSlider.setPaintLabels(true);
         throttleSlider.setPaintTicks(true);
         throttleSlider.setToolTipText(org.openide.util.NbBundle.getMessage(ProfileForm.class, "ProfileForm.throttleSlider.toolTipText")); // NOI18N
         throttleSlider.addChangeListener(new javax.swing.event.ChangeListener() {
@@ -381,12 +383,12 @@ public class ProfileForm extends JPanel {
         throttlePanelLayout.setVerticalGroup(
             throttlePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(throttlePanelLayout.createSequentialGroup()
-                .addGroup(throttlePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(throttleSlider, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGroup(throttlePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
+                    .addComponent(throttleSlider, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE)
                     .addGroup(throttlePanelLayout.createSequentialGroup()
                         .addContainerGap()
                         .addComponent(throttleLabel)))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addContainerGap(39, Short.MAX_VALUE))
         );
 
         profileProgressBar.setToolTipText(org.openide.util.NbBundle.getMessage(ProfileForm.class, "ProfileForm.profileProgressBar.toolTipText")); // NOI18N
@@ -434,7 +436,7 @@ public class ProfileForm extends JPanel {
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addComponent(jPanel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-            .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 826, Short.MAX_VALUE)
+            .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 868, Short.MAX_VALUE)
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)


### PR DESCRIPTION
changed two components in UI to remove visual issues: second menu row with icons which was cropped + bottom right throttle button which was showing an extra label on top of the throttle.

(code generated with netbeans GUI designer, and refined afterwards manually)

from
![image](https://user-images.githubusercontent.com/1750370/67794828-3ba07580-fa75-11e9-8e7a-a2910f6ea9ed.png)
to
![image](https://user-images.githubusercontent.com/1750370/67794854-4529dd80-fa75-11e9-8de2-2cb1216f5148.png)

compared to previous version run with Java 8 
![image](https://user-images.githubusercontent.com/1750370/67794872-4f4bdc00-fa75-11e9-9106-b623cdd29ca6.png)



