### PR TITLE
Only output exception stack traces when in debug mode.

### DIFF
--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionGateway.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionGateway.java
@@ -289,7 +289,11 @@ public class SubmissionGateway implements AsynchDroid {
                 }
                 final String message = String.format(ARCHIVE_ERROR, 
                         archiveFormat, request.getIdentifier().getUri().toString(), e.getMessage(), causeMessage);
-                log.warn(message, e);
+                if (log.isDebugEnabled()) {
+                    log.debug(message, e); // exception details included in debug.
+                } else {
+                    log.warn(message); // Just the message in normal operation.
+                }
                 resultHandler.handleError(new IdentificationException(
                         request, IdentificationErrorType.OTHER, e));
             } finally {


### PR DESCRIPTION
This small change gets rid of the contant exception stack trace in normal DROID operation processing awkward zip files, unless  you're in debug log mode - where you get the stack trace.

This makes looking at DROID output much easier in normal operation.   Mostly it's things like zip files which the library can't interpret, not errors in the software. Things that aren't actually errors shouldn't dump stack traces onto the warn log mode.