### PR TITLE
WORKAROUND for https://github.com/digital-preservation/droid/issues/306

### DIFF
--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.java
@@ -235,8 +235,7 @@ public class ProfileForm extends JPanel {
      */
     public void insertNodesAtPath(TreePath path) {
         int row = mdl.getLayout().getRowForPath(path);
-        TableModelEvent event = new TableModelEvent (mdl, row, row,
-                TableModelEvent.ALL_COLUMNS, TableModelEvent.INSERT);
+        TableModelEvent event = new TableModelEvent(mdl, row, row, TableModelEvent.ALL_COLUMNS, TableModelEvent.INSERT);
         resultsOutline.tableChanged(event);
     }
 

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.java
@@ -60,6 +60,7 @@ import javax.swing.JProgressBar;
 import javax.swing.JSlider;
 import javax.swing.JTable;
 import javax.swing.TransferHandler;
+import javax.swing.event.TableModelEvent;
 import javax.swing.event.TreeWillExpandListener;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
@@ -223,6 +224,20 @@ public class ProfileForm extends JPanel {
                 }
             }
         });
+    }
+
+    /**
+     * Workaround method to fire a TableModelEvent when a node is inserted at a tree path.
+     * This is documented in https://github.com/digital-preservation/droid/issues/306
+     * and is due to a bug in the netbeans outline component after version 8.0.  The fix is being
+     * tracked at Apache Netbeans as this PR: https://github.com/apache/netbeans/pull/1639
+     * @param path The TreePath at which a node was dynamically inserted.
+     */
+    public void insertNodesAtPath(TreePath path) {
+        int row = mdl.getLayout().getRowForPath(path);
+        TableModelEvent event = new TableModelEvent (mdl, row, row,
+                TableModelEvent.ALL_COLUMNS, TableModelEvent.INSERT);
+        resultsOutline.tableChanged(event);
     }
 
     /**

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ExpandingTreeListener.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ExpandingTreeListener.java
@@ -93,7 +93,7 @@ public class ExpandingTreeListener implements TreeWillExpandListener {
             //WORKAROUND: issue 306 - latest netbeans outline doesn't resort when node expands.
             // Once netbeans fixes the bug (tracked as this PR: https://github.com/apache/netbeans/pull/1639)
             // then we should not need this anymore.
-            profileForm.nodesInsertedAtPath(event.getPath());
+            profileForm.insertNodesAtPath(event.getPath());
 
         } finally {
             profileForm.setCursor(Cursor.getDefaultCursor());

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ExpandingTreeListener.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ExpandingTreeListener.java
@@ -85,12 +85,16 @@ public class ExpandingTreeListener implements TreeWillExpandListener {
                     profileForm.getInMemoryNodes().put(node.getId(), newNode);
                 }
             }
-            
+
             if (expandingNode.getChildCount() == 0) {
                 expandingNode.setAllowsChildren(false);
             }
-            
             profileForm.getTreeModel().nodeStructureChanged(expandingNode);
+            //WORKAROUND: issue 306 - latest netbeans outline doesn't resort when node expands.
+            // Once netbeans fixes the bug (tracked as this PR: https://github.com/apache/netbeans/pull/1639)
+            // then we should not need this anymore.
+            profileForm.nodesInsertedAtPath(event.getPath());
+
         } finally {
             profileForm.setCursor(Cursor.getDefaultCursor());
         }


### PR DESCRIPTION
  * force the tree to fire a TableModelEvent for a row which has
    had new nodes dynamically inserted in it.  This is due to a bug
    in later netbeans swing outline components.
  * The PR to fix it is at: https://github.com/apache/netbeans/pull/1639