### PR TITLE
add: comment in pom about hotfix on org-netbeans-swing-outline

### DIFF
--- a/droid-swing-ui/pom.xml
+++ b/droid-swing-ui/pom.xml
@@ -162,6 +162,11 @@
             <artifactId>org-openide-util</artifactId>
             <version>RELEASE112</version>
         </dependency>
+        <!--
+            droid-swing-ui has hotfix of org-netbeans-swing-outline:org.netbeans.swing.outline.TreePathSupport
+            If you need to update this library:
+            if bug fixed in later release, remove hotfix class ; otherwise make sure hotfix is still working
+        -->
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-swing-outline</artifactId>


### PR DESCRIPTION
to ensure good maintenance and prevent upgrading library while not taking into account overridden class