### PR TITLE
Shrink dependencies

### DIFF
--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -89,10 +89,6 @@
             <artifactId>jwat-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjrt</artifactId>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/PauseAspect.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/PauseAspect.java
@@ -34,15 +34,10 @@ package uk.gov.nationalarchives.droid.core.interfaces.control;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.aspectj.lang.annotation.After;
-import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Before;
-
 /**
  * @author rflitcroft
  *
  */
-@Aspect
 public class PauseAspect {
 
     private boolean isPaused;
@@ -54,8 +49,6 @@ public class PauseAspect {
     /**
      * Blocks until the executor is not paused.
      */
-    @Before("@annotation(uk.gov.nationalarchives.droid.core.interfaces.control.PauseBefore)")
-    @After("@annotation(uk.gov.nationalarchives.droid.core.interfaces.control.PauseAfter)")
     public void awaitUnpaused() {
         pauseLock.lock();
         try {

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -87,7 +87,6 @@
         <hibernate.version>5.4.1.Final</hibernate.version>
         <derby.version>10.13.1.1</derby.version>
         <cxf.version>3.3.4</cxf.version>
-        <aspectj.version>1.9.5</aspectj.version>
         <java.iso-tools.version>2.0.1</java.iso-tools.version>
         <jaxb.version>2.3.1</jaxb.version>
         <flying-saucer.version>9.1.19</flying-saucer.version>
@@ -540,16 +539,6 @@ Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="${project.organ
                 <groupId>net.byteseek</groupId>
                 <artifactId>byteseek</artifactId>
                 <version>2.0.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>aspectjrt</artifactId>
-                <version>${aspectj.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>aspectjweaver</artifactId>
-                <version>${aspectj.version}</version>
             </dependency>
             <dependency>
                 <groupId>xerces</groupId>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -231,12 +231,6 @@
 			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.transaction</groupId>
-			<artifactId>jta</artifactId>
-			<version>${jta.version}</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjweaver</artifactId>
 			<scope>runtime</scope>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -22,7 +22,6 @@
 
 	<properties>
 		<jta.version>1.1</jta.version>
-		<cglib.version>3.3.0</cglib.version>
 		<slf4j.version>1.7.25</slf4j.version>
 	</properties>
 
@@ -108,8 +107,6 @@
 							<ignoredUnusedDeclaredDependencies>
 								<ignoredUnusedDeclaredDependency>uk.gov.nationalarchives:droid-container:jar:${project.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>javax.transaction:jta:jar:${jta.version}</ignoredUnusedDeclaredDependency>
-								<ignoredUnusedDeclaredDependency>org.aspectj:aspectjweaver:jar:${aspectj.version}</ignoredUnusedDeclaredDependency>
-								<ignoredUnusedDeclaredDependency>cglib:cglib-nodep:jar:${cglib.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.apache.cxf:cxf-rt-frontend-jaxws:jar:${cxf.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.apache.cxf:cxf-rt-bindings-soap:jar:${cxf.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12:jar:${slf4j.version}</ignoredUnusedDeclaredDependency>
@@ -231,11 +228,6 @@
 			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.aspectj</groupId>
-			<artifactId>aspectjweaver</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
 		</dependency>
@@ -246,12 +238,6 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>cglib</groupId>
-			<artifactId>cglib-nodep</artifactId>
-			<version>${cglib.version}</version>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceManagerImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceManagerImpl.java
@@ -142,7 +142,6 @@ public class ProfileInstanceManagerImpl implements ProfileInstanceManager {
     }
 
     @Override
-    //@Transactional(propagation = Propagation.REQUIRED)
     public void initProfile(URI signatureFileUri) throws SignatureFileException {
 
 

--- a/droid-results/src/main/resources/META-INF/spring-jpa.xml
+++ b/droid-results/src/main/resources/META-INF/spring-jpa.xml
@@ -35,10 +35,8 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans" default-autowire="no"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
-http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.2.xsd">
+http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
   <!--
 To permit separation of profile runs and sets of profile results,

--- a/droid-results/src/main/resources/META-INF/spring-profile.xml
+++ b/droid-results/src/main/resources/META-INF/spring-profile.xml
@@ -35,9 +35,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans" default-autowire="no"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.2.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd">
 
     <bean id="profileManager" class="uk.gov.nationalarchives.droid.profile.ProfileManagerImpl">
         <!-- <property name="profileInstanceFactory" ref="profileInstanceFactory"/> -->

--- a/droid-results/src/main/resources/META-INF/spring-results.xml
+++ b/droid-results/src/main/resources/META-INF/spring-results.xml
@@ -35,12 +35,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
-http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.2.xsd">
+http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
 
 
     <bean id="archiveHandlerLocator"

--- a/droid-results/src/main/resources/META-INF/spring-results.xml
+++ b/droid-results/src/main/resources/META-INF/spring-results.xml
@@ -349,7 +349,6 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
     </bean>
 
     <context:annotation-config/>
-    <tx:annotation-driven transaction-manager="transactionManager" proxy-target-class="true"/>
     <aop:aspectj-autoproxy/>
 
 </beans>

--- a/droid-results/src/main/resources/META-INF/spring-results.xml
+++ b/droid-results/src/main/resources/META-INF/spring-results.xml
@@ -34,11 +34,9 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
-http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
+http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
 
     <bean id="archiveHandlerLocator"
@@ -328,6 +326,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
         <property name="droidCore" ref="droid"/>
         <property name="submissionQueue" ref="submissionQueue"/>
         <property name="replaySubmitter" ref="replaySubmitter"/>
+        <property name="pauseAspect" ref="pauseControl"/>
         <property name="hashGenerator" ref="${hashAlgorithm}HashGenerator"/>
     </bean>
 
@@ -347,6 +346,4 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
     </bean>
 
     <context:annotation-config/>
-    <aop:aspectj-autoproxy/>
-
 </beans>

--- a/droid-results/src/main/resources/META-INF/spring-signature.xml
+++ b/droid-results/src/main/resources/META-INF/spring-signature.xml
@@ -34,11 +34,9 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
-http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.2.xsd">
+http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
     
     <bean id="pronomClient" class="uk.gov.nationalarchives.pronom.PronomService"

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/planet/xml/dao/JpaPlanetsXMLDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/planet/xml/dao/JpaPlanetsXMLDaoTest.java
@@ -54,7 +54,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
-import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -71,7 +70,6 @@ import uk.gov.nationalarchives.droid.profile.FilterImpl;
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml",
         "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@Commit
 public class JpaPlanetsXMLDaoTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileDaoTest.java
@@ -53,7 +53,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
-import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -65,7 +64,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@Commit
 public class JpaProfileDaoTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileFilterTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileFilterTest.java
@@ -53,7 +53,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
-import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -68,7 +67,6 @@ import uk.gov.nationalarchives.droid.core.interfaces.filter.FilterValue;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@Commit
 public class JpaProfileFilterTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNodePersistenceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNodePersistenceTest.java
@@ -40,9 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceUtils;
-import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.transaction.annotation.Transactional;
 
 
 
@@ -54,8 +52,6 @@ import org.springframework.transaction.annotation.Transactional;
 //@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml", 
         "classpath*:META-INF/spring-test.xml" })
-@Commit
-@Transactional
 @Ignore
 public class ProfileResourceNodePersistenceTest {
 

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
@@ -55,7 +55,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -74,7 +73,6 @@ import javax.sql.DataSource;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring-jpa.xml", "classpath*:META-INF/spring-results.xml",
         "classpath*:META-INF/spring-test.xml" })
-@Commit
 public class JpaReportDaoTest {
 
     private static IDataSet testData;

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/SubmissionGatewayTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/SubmissionGatewayTest.java
@@ -63,6 +63,7 @@ import uk.gov.nationalarchives.droid.core.interfaces.archive.ArchiveFormatResolv
 import uk.gov.nationalarchives.droid.core.interfaces.archive.ArchiveHandlerFactory;
 import uk.gov.nationalarchives.droid.core.interfaces.archive.TrueZipArchiveHandler;
 import uk.gov.nationalarchives.droid.core.interfaces.archive.ZipEntryRequestFactory;
+import uk.gov.nationalarchives.droid.core.interfaces.control.PauseAspect;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.FileSystemIdentificationRequest;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.RequestMetaData;
 import uk.gov.nationalarchives.droid.core.SignatureParseException;
@@ -79,7 +80,9 @@ public class SubmissionGatewayTest {
         BinarySignatureIdentifier droid = new BinarySignatureIdentifier();
         SubmissionGateway submissionGateway = new SubmissionGateway();
         submissionGateway.setDroidCore(droid);
-        
+        PauseAspect pauseControl = new PauseAspect();
+        submissionGateway.setPauseAspect(pauseControl);
+
         droid.setSignatureFile("test_sig_files/DROID_SignatureFile_V26.xml");
         ResultHandler resultHandler = mock(ResultHandler.class);
         submissionGateway.setResultHandler(resultHandler);
@@ -173,7 +176,9 @@ public class SubmissionGatewayTest {
         SubmissionQueue submissionQueue = mock(SubmissionQueue.class);
         submissionGateway.setSubmissionQueue(submissionQueue);
         submissionGateway.setDroidCore(droid);
-        
+        PauseAspect pauseControl = new PauseAspect();
+        submissionGateway.setPauseAspect(pauseControl);
+
         droid.setSignatureFile("test_sig_files/DROID_SignatureFile_V26.xml");
         ResultHandler resultHandler = mock(ResultHandler.class);
         submissionGateway.setResultHandler(resultHandler);

--- a/droid-results/src/test/resources/META-INF/spring-test.xml
+++ b/droid-results/src/test/resources/META-INF/spring-test.xml
@@ -34,9 +34,7 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.2.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd">
 
     <bean id="properties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="locations">


### PR DESCRIPTION
There's a couple of unnecessary dependencies in DROID.

1.  spring transaction isn't actually used in DROID any more.
2.  aspect oriented programming (AOP) was being used to inject code into a single method.

This PR removes the references to unused dependencies, and gets rid of the completely unnecessary use of AOP, and instead just injects the required class in the single place it's needed using normal Spring.