### PR TITLE
Only parse container sigs once

### DIFF
--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureFileReader.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureFileReader.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.gov.nationalarchives.droid.container;
+
+import uk.gov.nationalarchives.droid.core.SignatureParseException;
+
+import javax.xml.bind.JAXBException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * A simple class that reads and parses a container signature file once,
+ * and caches the container signature definitions created, so the file isn't repeatedly parsed.
+ */
+public class ContainerSignatureFileReader {
+
+    private String filePath = "";
+    private ContainerSignatureDefinitions definitions;
+
+    /**
+     * Empty bean constructor.
+     */
+    public ContainerSignatureFileReader() {
+    }
+
+    /**
+     * Parameterized constructor.
+     *
+     * @param filepath The path of the container signature file to parse.
+     */
+    public ContainerSignatureFileReader(String filepath) {
+        this.filePath = filepath;
+    }
+
+    /**
+     * Constructs a ContainerSignatureFileReader from a Path.
+     * @param path The path to the signature file.
+     */
+    public ContainerSignatureFileReader(Path path) {
+        this.filePath = path.toFile().getPath();
+    }
+
+    /**
+     * Sets the file path of the container signature file.
+     * @param filePath
+     */
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    /**
+     * @return The file path of the container signature file.
+     */
+    public String getFilePath() {
+        return filePath;
+    }
+
+    /**
+     * @return The parsed definitions of the container signature file.
+     * @throws SignatureParseException If there was any problem reading or parsing the signature file.
+     */
+    public synchronized ContainerSignatureDefinitions getDefinitions() throws SignatureParseException {
+        if (definitions == null) {
+            try {
+                ContainerSignatureSaxParser parser = new ContainerSignatureSaxParser();
+                try (FileInputStream containerFileStream = new FileInputStream(new File(filePath))) {
+                    definitions = parser.parse(containerFileStream);
+                }
+            } catch (JAXBException | IOException ex) {
+                throw new SignatureParseException(ex.getMessage(), ex);
+            }
+        }
+        return definitions;
+    }
+}

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureFileReader.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureFileReader.java
@@ -31,13 +31,14 @@
  */
 package uk.gov.nationalarchives.droid.container;
 
-import uk.gov.nationalarchives.droid.core.SignatureParseException;
-
-import javax.xml.bind.JAXBException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+
+import javax.xml.bind.JAXBException;
+
+import uk.gov.nationalarchives.droid.core.SignatureParseException;
 
 /**
  * A simple class that reads and parses a container signature file once,
@@ -73,7 +74,7 @@ public class ContainerSignatureFileReader {
 
     /**
      * Sets the file path of the container signature file.
-     * @param filePath
+     * @param filePath The file path of the signature file.
      */
     public void setFilePath(String filePath) {
         this.filePath = filePath;

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/odf/OdfIdentifierTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/odf/OdfIdentifierTest.java
@@ -54,6 +54,7 @@ import org.junit.Test;
 
 import uk.gov.nationalarchives.droid.container.ContainerFile;
 import uk.gov.nationalarchives.droid.container.ContainerSignature;
+import uk.gov.nationalarchives.droid.container.ContainerSignatureFileReader;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureSaxParser;
 import uk.gov.nationalarchives.droid.container.FileFormatMapping;
 import uk.gov.nationalarchives.droid.container.zip.ZipIdentifier;
@@ -148,11 +149,8 @@ public class OdfIdentifierTest {
 
         odfIdentifier.setContainerIdentifierFactory(containerIdentifierFactory);
         odfIdentifier.setContainerFormatResolver(containerFormatResolver);
-        
-        odfIdentifier.setSignatureFileParser(new ContainerSignatureSaxParser());
+        odfIdentifier.setSignatureReader(new ContainerSignatureFileReader(path));
         odfIdentifier.setContainerType("ZIP");
-        odfIdentifier.setSignatureFilePath(path);
-
         odfIdentifier.init();
         
         verify(containerIdentifierFactory, times(2)).addContainerIdentifier("ZIP", odfIdentifier);
@@ -173,11 +171,8 @@ public class OdfIdentifierTest {
 
         odfIdentifier.setContainerIdentifierFactory(containerIdentifierFactory);
         odfIdentifier.setContainerFormatResolver(containerFormatResolver);
-        
-        odfIdentifier.setSignatureFileParser(new ContainerSignatureSaxParser());
+        odfIdentifier.setSignatureReader(new ContainerSignatureFileReader(path));
         odfIdentifier.setContainerType("ZIP");
-        odfIdentifier.setSignatureFilePath(path);
-
         odfIdentifier.init();
         
         verify(containerIdentifierFactory, times(2)).addContainerIdentifier("ZIP", odfIdentifier);

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ole2/Ole2RootFileTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ole2/Ole2RootFileTest.java
@@ -271,11 +271,7 @@ public class Ole2RootFileTest {
 
         ole2Identifier.setContainerIdentifierFactory(containerIdentifierFactory);
         ole2Identifier.setContainerFormatResolver(containerFormatResolver);
-
-        //TODO: fix
-        //ContainerSignatureFileReader reader = new ContainerSignatureFileReader(path.);
-
-        //ole2Identifier.setSignatureReader(reader);
+        ole2Identifier.setSignatureReader(new ContainerSignatureFileReader(path));
         ole2Identifier.setContainerType("OLE2");
         IdentificationRequestFactory requestFactory = mock(IdentificationRequestFactory.class);
         

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ole2/Ole2RootFileTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ole2/Ole2RootFileTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 
 import uk.gov.nationalarchives.droid.container.ContainerFile;
 import uk.gov.nationalarchives.droid.container.ContainerSignature;
+import uk.gov.nationalarchives.droid.container.ContainerSignatureFileReader;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureSaxParser;
 import uk.gov.nationalarchives.droid.container.FileFormatMapping;
 import uk.gov.nationalarchives.droid.core.interfaces.DroidCore;
@@ -270,10 +271,12 @@ public class Ole2RootFileTest {
 
         ole2Identifier.setContainerIdentifierFactory(containerIdentifierFactory);
         ole2Identifier.setContainerFormatResolver(containerFormatResolver);
-        
-        ole2Identifier.setSignatureFileParser(new ContainerSignatureSaxParser());
+
+        //TODO: fix
+        //ContainerSignatureFileReader reader = new ContainerSignatureFileReader(path.);
+
+        //ole2Identifier.setSignatureReader(reader);
         ole2Identifier.setContainerType("OLE2");
-        ole2Identifier.setSignatureFilePath(path);
         IdentificationRequestFactory requestFactory = mock(IdentificationRequestFactory.class);
         
         IdentificationRequest request = mock(IdentificationRequest.class);
@@ -300,10 +303,8 @@ public class Ole2RootFileTest {
 
         ole2Identifier.setContainerIdentifierFactory(containerIdentifierFactory);
         ole2Identifier.setContainerFormatResolver(containerFormatResolver);
-        
-        ole2Identifier.setSignatureFileParser(new ContainerSignatureSaxParser());
         ole2Identifier.setContainerType("OLE2");
-        ole2Identifier.setSignatureFilePath(path);
+        ole2Identifier.setSignatureReader(new ContainerSignatureFileReader(path));
         ole2Identifier.init();
         
         verify(containerIdentifierFactory).addContainerIdentifier("OLE2", ole2Identifier);
@@ -324,9 +325,7 @@ public class Ole2RootFileTest {
         ole2Identifier.setContainerFormatResolver(containerFormatResolver);
         DroidCore droidCore = mock(DroidCore.class);
         ole2Identifier.setDroidCore(droidCore);
-        
-        ole2Identifier.setSignatureFileParser(new ContainerSignatureSaxParser());
-        ole2Identifier.setSignatureFilePath(path);
+        ole2Identifier.setSignatureReader(new ContainerSignatureFileReader(path));
         ole2Identifier.init();
         
         verify(droidCore).removeSignatureForPuid("fmt/39");

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ooxml/OoXmlIdentifierTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ooxml/OoXmlIdentifierTest.java
@@ -54,6 +54,7 @@ import org.junit.Test;
 
 import uk.gov.nationalarchives.droid.container.ContainerFile;
 import uk.gov.nationalarchives.droid.container.ContainerSignature;
+import uk.gov.nationalarchives.droid.container.ContainerSignatureFileReader;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureSaxParser;
 import uk.gov.nationalarchives.droid.container.FileFormatMapping;
 import uk.gov.nationalarchives.droid.container.zip.ZipIdentifier;
@@ -132,10 +133,8 @@ public class OoXmlIdentifierTest {
         
         ArchiveFormatResolver containerFormatResolver = mock(ArchiveFormatResolver.class);
         ooXmlIdentifier.setContainerFormatResolver(containerFormatResolver);
-
-        ooXmlIdentifier.setSignatureFileParser(new ContainerSignatureSaxParser());
+        ooXmlIdentifier.setSignatureReader(new ContainerSignatureFileReader(path));
         ooXmlIdentifier.setContainerType("ZIP");
-        ooXmlIdentifier.setSignatureFilePath(path);
         ooXmlIdentifier.init();
         
         List<ContainerSignature> containerSignatures = ooXmlIdentifier.getContainerSignatures();
@@ -164,11 +163,8 @@ public class OoXmlIdentifierTest {
         
         ooXmlIdentifier.setContainerIdentifierFactory(containerIdentifierFactory);
         ooXmlIdentifier.setContainerFormatResolver(containerFormatResolver);
-        
-        ooXmlIdentifier.setSignatureFileParser(new ContainerSignatureSaxParser());
+        ooXmlIdentifier.setSignatureReader(new ContainerSignatureFileReader(path));
         ooXmlIdentifier.setContainerType("ZIP");
-        ooXmlIdentifier.setSignatureFilePath(path);
-
         ooXmlIdentifier.init();
         
         verify(containerIdentifierFactory, times(2)).addContainerIdentifier("ZIP", ooXmlIdentifier);
@@ -186,13 +182,10 @@ public class OoXmlIdentifierTest {
         
         DroidCore droidCore = mock(DroidCore.class);
         ooXmlIdentifier.setDroidCore(droidCore);
-
         ooXmlIdentifier.setContainerIdentifierFactory(containerIdentifierFactory);
         ooXmlIdentifier.setContainerFormatResolver(containerFormatResolver);
-        
-        ooXmlIdentifier.setSignatureFileParser(new ContainerSignatureSaxParser());
+        ooXmlIdentifier.setSignatureReader(new ContainerSignatureFileReader(path));
         ooXmlIdentifier.setContainerType("ZIP");
-        ooXmlIdentifier.setSignatureFilePath(path);
         ooXmlIdentifier.init();
         
         verify(containerIdentifierFactory, times(2)).addContainerIdentifier("ZIP", ooXmlIdentifier);

--- a/droid-results/src/main/resources/META-INF/spring-results.xml
+++ b/droid-results/src/main/resources/META-INF/spring-results.xml
@@ -74,16 +74,17 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
         <property name="requestFactory" ref="containerFileIdentificationRequestFactory"/>
     </bean>
 
+    <bean id="signatureFileReader" class="uk.gov.nationalarchives.droid.container.ContainerSignatureFileReader">
+        <property name="filePath" value="${containerSigPath}"/>
+    </bean>
+
     <bean id="zipContainerHandler" class="uk.gov.nationalarchives.droid.container.zip.ZipIdentifier" init-method="init">
-        <property name="signatureFileParser">
-            <bean class="uk.gov.nationalarchives.droid.container.ContainerSignatureSaxParser"/>
-        </property>
-        <property name="signatureFilePath" value="${containerSigPath}"/>
         <property name="containerType" value="ZIP"/>
         <property name="containerIdentifierFactory" ref="containerIdentifierLocator"/>
         <property name="containerFormatResolver" ref="containerPuidResolver"/>
         <property name="droidCore" ref="droid"/>
         <property name="identifierEngine" ref="zipIdentifierEngine"/>
+        <property name="signatureReader" ref="signatureFileReader"/>
     </bean>
 
     <bean id="ole2IdentifierEngine" class="uk.gov.nationalarchives.droid.container.ole2.Ole2IdentifierEngine">
@@ -92,15 +93,12 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 
     <bean id="ole2ContainerHandler" class="uk.gov.nationalarchives.droid.container.ole2.Ole2Identifier"
           init-method="init">
-        <property name="signatureFileParser">
-            <bean class="uk.gov.nationalarchives.droid.container.ContainerSignatureSaxParser"/>
-        </property>
-        <property name="signatureFilePath" value="${containerSigPath}"/>
         <property name="containerType" value="OLE2"/>
         <property name="containerIdentifierFactory" ref="containerIdentifierLocator"/>
         <property name="containerFormatResolver" ref="containerPuidResolver"/>
         <property name="droidCore" ref="droid"/>
         <property name="identifierEngine" ref="ole2IdentifierEngine"/>
+        <property name="signatureReader" ref="signatureFileReader"/>
     </bean>
 
     <bean id="archiveRequestFactory" abstract="true">


### PR DESCRIPTION
At present the container signature file is parsed twice: once when the ZipIdentifier is instantiated, and again when the OLE2Identifier is.

This PR creates a new bean that caches the container signature definitions, and modifies the container identifiers to use the bean instead of parsing the file themselves.