### PR TITLE
Add filetype selection in CLI 

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
+import uk.gov.nationalarchives.droid.command.archive.ArchiveConfiguration;
 import uk.gov.nationalarchives.droid.command.archive.Bzip2ArchiveContentIdentifier;
 import uk.gov.nationalarchives.droid.command.archive.GZipArchiveContentIdentifier;
 import uk.gov.nationalarchives.droid.command.archive.IsoArchiveContainerIdentifier;
@@ -95,8 +96,7 @@ public class ResultPrinter {
     private String slash1;
     private String wrongSlash;
     private boolean archives;
-    private boolean expandAllWebArchives;
-    private String[] webArchiveTypes;
+    private ArchiveConfiguration archiveConfiguration;
 
     /**
      * Store signature files.
@@ -106,12 +106,11 @@ public class ResultPrinter {
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
      * @param archives                      Should archives be examined?
-     * @param expandAllWebArchives                   Should web archives be examined?
-     * @param webArchiveTypes               Which web archive types should be examined?
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public ResultPrinter(final BinarySignatureIdentifier binarySignatureIdentifier,
                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                         final String path, final String slash, final String slash1, boolean archives, boolean expandAllWebArchives, String[] webArchiveTypes) {
+                         final String path, final String slash, final String slash1, boolean archives, ArchiveConfiguration archiveConfiguration) {
 
         this.binarySignatureIdentifier = binarySignatureIdentifier;
         this.containerSignatureDefinitions = containerSignatureDefinitions;
@@ -120,40 +119,12 @@ public class ResultPrinter {
         this.slash1 = slash1;
         this.wrongSlash = this.slash.equals(R_SLASH) ? DOUBLE_SLASH : R_SLASH;
         this.archives = archives;
-        this.expandAllWebArchives = expandAllWebArchives;
-        this.webArchiveTypes = webArchiveTypes;
+        this.archiveConfiguration = archiveConfiguration;
         if (containerSignatureDefinitions != null) {
             triggerPuids = containerSignatureDefinitions.getTiggerPuids();
         }
     }
 
-    /**
-     * Store signature files.
-     *  @param binarySignatureIdentifier     binary signature identifier
-     * @param containerSignatureDefinitions container signatures
-     * @param path                          current file/container path
-     * @param slash                         local path element delimiter
-     * @param slash1                        local first container prefix delimiter
-     * @param archives                      Should archives be examined?
-     * @param expandAllWebArchives                   Should web archives be examined?
-     */
-    public ResultPrinter(final BinarySignatureIdentifier binarySignatureIdentifier,
-                         final ContainerSignatureDefinitions containerSignatureDefinitions,
-                         final String path, final String slash, final String slash1, boolean archives, boolean expandAllWebArchives) {
-
-        this.binarySignatureIdentifier = binarySignatureIdentifier;
-        this.containerSignatureDefinitions = containerSignatureDefinitions;
-        this.path = path;
-        this.slash = slash;
-        this.slash1 = slash1;
-        this.wrongSlash = this.slash.equals(R_SLASH) ? DOUBLE_SLASH : R_SLASH;
-        this.archives = archives;
-        this.expandAllWebArchives = expandAllWebArchives;
-        if (containerSignatureDefinitions != null) {
-            triggerPuids = containerSignatureDefinitions.getTiggerPuids();
-        }
-    }
-    
     /**
      * Output identification for this file.
      * 
@@ -193,48 +164,48 @@ public class ResultPrinter {
                         if (GZIP_ARCHIVE.equals(puid)) {
                             GZipArchiveContentIdentifier gzipArchiveIdentifier =
                                     new GZipArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                             gzipArchiveIdentifier.identify(results.getUri(), request);
                         } else if (TAR_ARCHIVE.equals(puid)) {
                             TarArchiveContentIdentifier tarArchiveIdentifier =
                                     new TarArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                             tarArchiveIdentifier.identify(results.getUri(), request);
                         } else if (ZIP_ARCHIVE.equals(puid) || JIP_ARCHIVE.equals(puid)) {
                             ZipArchiveContentIdentifier zipArchiveIdentifier =
                                     new ZipArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                             zipArchiveIdentifier.identify(results.getUri(), request);
                         } else if (ISO_9660.equals(puid)) {
                             IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
                                     new IsoArchiveContainerIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                             isoArchiveContainerIdentifier.identify(results.getUri(), request);
                         } else if (SEVEN_ZIP.equals(puid)) {
                             SevenZipArchiveContainerIdentifier sevenZipArchiveContainerIdentifier =
                                     new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                             sevenZipArchiveContainerIdentifier.identify(results.getUri(), request);
                         } else if (BZIP2_ARCHIVE.equals(puid)) {
                             Bzip2ArchiveContentIdentifier bzip2ArchiveContentIdentifier =
                                     new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                             bzip2ArchiveContentIdentifier.identify(results.getUri(), request);
                         }
                     }
                 }
-                if ((expandAllWebArchives || containsCaseInsensitive("ARC", webArchiveTypes))
+                if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("ARC", archiveConfiguration.getExpandWebArchiveTypes()))
                         && (ARC_ARCHIVE.equals(puid) || OTHERARC_ARCHIVE.equals(puid))) {
                     ArcArchiveContentIdentifier arcArchiveIdentifier =
                             new ArcArchiveContentIdentifier(binarySignatureIdentifier,
-                                    containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
+                                    containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                     arcArchiveIdentifier.identify(results.getUri(), request);
                 }
-                if ((expandAllWebArchives || containsCaseInsensitive("WARC", webArchiveTypes))
+                if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("WARC", archiveConfiguration.getExpandWebArchiveTypes()))
                     && (WARC_ARCHIVE.equals(puid))) {
                     WarcArchiveContentIdentifier warcArchiveIdentifier =
                             new WarcArchiveContentIdentifier(binarySignatureIdentifier,
-                                    containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
+                                    containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                     warcArchiveIdentifier.identify(results.getUri(), request);
                 }
             }
@@ -244,6 +215,9 @@ public class ResultPrinter {
     }
 
     public boolean containsCaseInsensitive(String needle, String[] haystack) {
+        if(haystack==null){
+            return false;
+        }
         return Arrays.stream(haystack).anyMatch(x -> x.equalsIgnoreCase(needle));
     }
 
@@ -308,5 +282,21 @@ public class ResultPrinter {
             }
         }
         return null;
+    }
+
+    /**
+     *
+     * @return configuration to expand web archives and archives
+     */
+    public ArchiveConfiguration getArchiveConfiguration() {
+        return archiveConfiguration;
+    }
+
+    /**
+     *
+     * @param archiveConfiguration configuration to expand web archives and archives
+     */
+    public void setArchiveConfiguration(ArchiveConfiguration archiveConfiguration) {
+        this.archiveConfiguration = archiveConfiguration;
     }
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -188,20 +188,20 @@ public class ResultPrinter {
                                         containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                         bzip2ArchiveContentIdentifier.identify(results.getUri(), request);
                     }
-                }
-                if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("ARC", archiveConfiguration.getExpandWebArchiveTypes()))
-                        && (ARC_ARCHIVE.equals(puid) || OTHERARC_ARCHIVE.equals(puid))) {
-                    ArcArchiveContentIdentifier arcArchiveIdentifier =
-                            new ArcArchiveContentIdentifier(binarySignatureIdentifier,
-                                    containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                    arcArchiveIdentifier.identify(results.getUri(), request);
-                }
-                if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("WARC", archiveConfiguration.getExpandWebArchiveTypes()))
-                    && (WARC_ARCHIVE.equals(puid))) {
-                    WarcArchiveContentIdentifier warcArchiveIdentifier =
-                            new WarcArchiveContentIdentifier(binarySignatureIdentifier,
-                                    containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                    warcArchiveIdentifier.identify(results.getUri(), request);
+                    if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("ARC", archiveConfiguration.getExpandWebArchiveTypes()))
+                            && (ARC_ARCHIVE.equals(puid) || OTHERARC_ARCHIVE.equals(puid))) {
+                        ArcArchiveContentIdentifier arcArchiveIdentifier =
+                                new ArcArchiveContentIdentifier(binarySignatureIdentifier,
+                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                        arcArchiveIdentifier.identify(results.getUri(), request);
+                    }
+                    if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("WARC", archiveConfiguration.getExpandWebArchiveTypes()))
+                        && (WARC_ARCHIVE.equals(puid))) {
+                        WarcArchiveContentIdentifier warcArchiveIdentifier =
+                                new WarcArchiveContentIdentifier(binarySignatureIdentifier,
+                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                        warcArchiveIdentifier.identify(results.getUri(), request);
+                    }
                 }
             }
         } else {

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -78,15 +78,16 @@ public class ResultPrinter {
     private static final String ZIP = "ZIP";
     private static final String ZIP_ARCHIVE = "x-fmt/263";
     private static final String RAR_ARCHIVE = "x-fmt/264";
-    private static final String OTHERRAR_ARCHIVE = "fmt/411";
+    private static final String RAR_ARCHIVE_OTHER = "fmt/411";
     private static final String TAR_ARCHIVE = "x-fmt/265";
     private static final String GZIP_ARCHIVE = "x-fmt/266";
     private static final String ARC_ARCHIVE = "x-fmt/219";
-    private static final String OTHERARC_ARCHIVE = "fmt/410";
+    private static final String ARC_ARCHIVE_OTHER = "fmt/410";
     private static final String WARC_ARCHIVE = "fmt/289";
     private static final String ISO_9660 = "fmt/468";
     private static final String SEVEN_ZIP = "fmt/484";
-    private static final String BZIP2_ARCHIVE = "x-fmt/268";
+    private static final String BZIP2_ARCHIVE = "x-fmt/267";
+    private static final String BZIP2_ARCHIVE_OTHER = "x-fmt/268";
 
 
     private BinarySignatureIdentifier binarySignatureIdentifier;
@@ -198,6 +199,7 @@ public class ResultPrinter {
                             }
                             break;
                         case BZIP2_ARCHIVE:
+                        case BZIP2_ARCHIVE_OTHER:
                             if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("BZIP2", archiveConfiguration.getExpandArchiveTypes()))) {
                                 Bzip2ArchiveContentIdentifier bzip2ArchiveContentIdentifier =
                                         new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
@@ -206,7 +208,7 @@ public class ResultPrinter {
                             }
                             break;
                         case RAR_ARCHIVE:
-                        case OTHERRAR_ARCHIVE:
+                        case RAR_ARCHIVE_OTHER:
                             if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("RAR", archiveConfiguration.getExpandArchiveTypes()))) {
                                 RarArchiveContainerIdentifier rarArchiveContentIdentifier =
                                         new RarArchiveContainerIdentifier(binarySignatureIdentifier,
@@ -216,7 +218,7 @@ public class ResultPrinter {
                             break;
 
                         case ARC_ARCHIVE:
-                        case OTHERARC_ARCHIVE:
+                        case ARC_ARCHIVE_OTHER:
                             if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("ARC", archiveConfiguration.getExpandWebArchiveTypes()))) {
                                 ArcArchiveContentIdentifier arcArchiveIdentifier =
                                         new ArcArchiveContentIdentifier(binarySignatureIdentifier,

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -95,7 +95,7 @@ public class ResultPrinter {
     private String slash1;
     private String wrongSlash;
     private boolean archives;
-    private boolean webArchives;
+    private boolean expandAllWebArchives;
     private String[] webArchiveTypes;
 
     /**
@@ -106,12 +106,12 @@ public class ResultPrinter {
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
      * @param archives                      Should archives be examined?
-     * @param webArchives                   Should web archives be examined?
+     * @param expandAllWebArchives                   Should web archives be examined?
      * @param webArchiveTypes               Which web archive types should be examined?
      */
     public ResultPrinter(final BinarySignatureIdentifier binarySignatureIdentifier,
                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                         final String path, final String slash, final String slash1, boolean archives, boolean webArchives, String[] webArchiveTypes) {
+                         final String path, final String slash, final String slash1, boolean archives, boolean expandAllWebArchives, String[] webArchiveTypes) {
 
         this.binarySignatureIdentifier = binarySignatureIdentifier;
         this.containerSignatureDefinitions = containerSignatureDefinitions;
@@ -120,7 +120,7 @@ public class ResultPrinter {
         this.slash1 = slash1;
         this.wrongSlash = this.slash.equals(R_SLASH) ? DOUBLE_SLASH : R_SLASH;
         this.archives = archives;
-        this.webArchives = webArchives;
+        this.expandAllWebArchives = expandAllWebArchives;
         this.webArchiveTypes = webArchiveTypes;
         if (containerSignatureDefinitions != null) {
             triggerPuids = containerSignatureDefinitions.getTiggerPuids();
@@ -135,11 +135,11 @@ public class ResultPrinter {
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
      * @param archives                      Should archives be examined?
-     * @param webArchives                   Should web archives be examined?
+     * @param expandAllWebArchives                   Should web archives be examined?
      */
     public ResultPrinter(final BinarySignatureIdentifier binarySignatureIdentifier,
                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                         final String path, final String slash, final String slash1, boolean archives, boolean webArchives) {
+                         final String path, final String slash, final String slash1, boolean archives, boolean expandAllWebArchives) {
 
         this.binarySignatureIdentifier = binarySignatureIdentifier;
         this.containerSignatureDefinitions = containerSignatureDefinitions;
@@ -148,7 +148,7 @@ public class ResultPrinter {
         this.slash1 = slash1;
         this.wrongSlash = this.slash.equals(R_SLASH) ? DOUBLE_SLASH : R_SLASH;
         this.archives = archives;
-        this.webArchives = webArchives;
+        this.expandAllWebArchives = expandAllWebArchives;
         if (containerSignatureDefinitions != null) {
             triggerPuids = containerSignatureDefinitions.getTiggerPuids();
         }
@@ -193,48 +193,48 @@ public class ResultPrinter {
                         if (GZIP_ARCHIVE.equals(puid)) {
                             GZipArchiveContentIdentifier gzipArchiveIdentifier =
                                     new GZipArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, webArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
                             gzipArchiveIdentifier.identify(results.getUri(), request);
                         } else if (TAR_ARCHIVE.equals(puid)) {
                             TarArchiveContentIdentifier tarArchiveIdentifier =
                                     new TarArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, webArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
                             tarArchiveIdentifier.identify(results.getUri(), request);
                         } else if (ZIP_ARCHIVE.equals(puid) || JIP_ARCHIVE.equals(puid)) {
                             ZipArchiveContentIdentifier zipArchiveIdentifier =
                                     new ZipArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, webArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
                             zipArchiveIdentifier.identify(results.getUri(), request);
                         } else if (ISO_9660.equals(puid)) {
                             IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
                                     new IsoArchiveContainerIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, webArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
                             isoArchiveContainerIdentifier.identify(results.getUri(), request);
                         } else if (SEVEN_ZIP.equals(puid)) {
                             SevenZipArchiveContainerIdentifier sevenZipArchiveContainerIdentifier =
                                     new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, webArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
                             sevenZipArchiveContainerIdentifier.identify(results.getUri(), request);
                         } else if (BZIP2_ARCHIVE.equals(puid)) {
                             Bzip2ArchiveContentIdentifier bzip2ArchiveContentIdentifier =
                                     new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, webArchives, webArchiveTypes);
+                                            containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
                             bzip2ArchiveContentIdentifier.identify(results.getUri(), request);
                         }
                     }
                 }
-                if ((webArchives || containsCaseInsensitive("ARC", webArchiveTypes))
+                if ((expandAllWebArchives || containsCaseInsensitive("ARC", webArchiveTypes))
                         && (ARC_ARCHIVE.equals(puid) || OTHERARC_ARCHIVE.equals(puid))) {
                     ArcArchiveContentIdentifier arcArchiveIdentifier =
                             new ArcArchiveContentIdentifier(binarySignatureIdentifier,
-                                    containerSignatureDefinitions, path, slash, slash1, webArchives, webArchiveTypes);
+                                    containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
                     arcArchiveIdentifier.identify(results.getUri(), request);
                 }
-                if ((webArchives || containsCaseInsensitive("WARC", webArchiveTypes))
+                if ((expandAllWebArchives || containsCaseInsensitive("WARC", webArchiveTypes))
                     && (WARC_ARCHIVE.equals(puid))) {
                     WarcArchiveContentIdentifier warcArchiveIdentifier =
                             new WarcArchiveContentIdentifier(binarySignatureIdentifier,
-                                    containerSignatureDefinitions, path, slash, slash1, webArchives, webArchiveTypes);
+                                    containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, webArchiveTypes);
                     warcArchiveIdentifier.identify(results.getUri(), request);
                 }
             }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -36,15 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
-import uk.gov.nationalarchives.droid.command.archive.ArchiveConfiguration;
-import uk.gov.nationalarchives.droid.command.archive.Bzip2ArchiveContentIdentifier;
-import uk.gov.nationalarchives.droid.command.archive.GZipArchiveContentIdentifier;
-import uk.gov.nationalarchives.droid.command.archive.IsoArchiveContainerIdentifier;
-import uk.gov.nationalarchives.droid.command.archive.SevenZipArchiveContainerIdentifier;
-import uk.gov.nationalarchives.droid.command.archive.ZipArchiveContentIdentifier;
-import uk.gov.nationalarchives.droid.command.archive.TarArchiveContentIdentifier;
-import uk.gov.nationalarchives.droid.command.archive.ArcArchiveContentIdentifier;
-import uk.gov.nationalarchives.droid.command.archive.WarcArchiveContentIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.*;
 import uk.gov.nationalarchives.droid.command.container.Ole2ContainerContentIdentifier;
 import uk.gov.nationalarchives.droid.command.container.ZipContainerContentIdentifier;
 import uk.gov.nationalarchives.droid.container.ContainerFileIdentificationRequestFactory;
@@ -76,6 +68,8 @@ public class ResultPrinter {
     private static final String OLE2_CONTAINER = "OLE2";
     private static final String ZIP = "ZIP";
     private static final String ZIP_ARCHIVE = "x-fmt/263";
+    private static final String RAR_ARCHIVE = "x-fmt/264";
+    private static final String OTHERRAR_ARCHIVE = "fmt/411";
     private static final String JIP_ARCHIVE = "x-fmt/412";
     private static final String TAR_ARCHIVE = "x-fmt/265";
     private static final String GZIP_ARCHIVE = "x-fmt/266";
@@ -205,6 +199,15 @@ public class ResultPrinter {
                                         new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
                                                 containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
                                 bzip2ArchiveContentIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
+                        case RAR_ARCHIVE:
+                        case OTHERRAR_ARCHIVE:
+                            if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("RAR", archiveConfiguration.getExpandArchiveTypes()))) {
+                                RarArchiveContainerIdentifier rarArchiveContentIdentifier =
+                                        new RarArchiveContainerIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                rarArchiveContentIdentifier.identify(results.getUri(), request);
                             }
                             break;
 

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -36,7 +36,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
-import uk.gov.nationalarchives.droid.command.archive.*;
+import uk.gov.nationalarchives.droid.command.archive.ArchiveConfiguration;
+import uk.gov.nationalarchives.droid.command.archive.Bzip2ArchiveContentIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.GZipArchiveContentIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.IsoArchiveContainerIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.RarArchiveContainerIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.SevenZipArchiveContainerIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.ZipArchiveContentIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.TarArchiveContentIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.ArcArchiveContentIdentifier;
+import uk.gov.nationalarchives.droid.command.archive.WarcArchiveContentIdentifier;
 import uk.gov.nationalarchives.droid.command.container.Ole2ContainerContentIdentifier;
 import uk.gov.nationalarchives.droid.command.container.ZipContainerContentIdentifier;
 import uk.gov.nationalarchives.droid.container.ContainerFileIdentificationRequestFactory;
@@ -70,7 +79,6 @@ public class ResultPrinter {
     private static final String ZIP_ARCHIVE = "x-fmt/263";
     private static final String RAR_ARCHIVE = "x-fmt/264";
     private static final String OTHERRAR_ARCHIVE = "fmt/411";
-    private static final String JIP_ARCHIVE = "x-fmt/412";
     private static final String TAR_ARCHIVE = "x-fmt/265";
     private static final String GZIP_ARCHIVE = "x-fmt/266";
     private static final String ARC_ARCHIVE = "x-fmt/219";
@@ -146,9 +154,6 @@ public class ResultPrinter {
         if (finalResults.getResults().size() > 0) {
             for (IdentificationResult identResult : finalResults.getResults()) {
                 String puid = identResult.getPuid();
-                if (!container && JIP_ARCHIVE.equals(puid)) {
-                    puid = ZIP_ARCHIVE;
-                }
                 System.out.println(fileName + "," + puid);
                 if (!container) {
                     switch (puid){
@@ -169,7 +174,6 @@ public class ResultPrinter {
                             }
                             break;
                         case ZIP_ARCHIVE:
-//                        case JIP_ARCHIVE:
                             if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive(ZIP, archiveConfiguration.getExpandArchiveTypes()))) {
                                 ZipArchiveContentIdentifier zipArchiveIdentifier =
                                         new ZipArchiveContentIdentifier(binarySignatureIdentifier,

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -157,51 +157,76 @@ public class ResultPrinter {
                 }
                 System.out.println(fileName + "," + puid);
                 if (!container) {
-                    if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("GZIP", archiveConfiguration.getExpandArchiveTypes())) && GZIP_ARCHIVE.equals(puid)) {
-                        GZipArchiveContentIdentifier gzipArchiveIdentifier =
-                                new GZipArchiveContentIdentifier(binarySignatureIdentifier,
-                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                        gzipArchiveIdentifier.identify(results.getUri(), request);
-                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("TAR", archiveConfiguration.getExpandArchiveTypes())) && TAR_ARCHIVE.equals(puid)) {
-                        TarArchiveContentIdentifier tarArchiveIdentifier =
-                                new TarArchiveContentIdentifier(binarySignatureIdentifier,
-                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                        tarArchiveIdentifier.identify(results.getUri(), request);
-                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive(ZIP, archiveConfiguration.getExpandArchiveTypes())) && ZIP_ARCHIVE.equals(puid) || JIP_ARCHIVE.equals(puid)) {
-                        ZipArchiveContentIdentifier zipArchiveIdentifier =
-                                new ZipArchiveContentIdentifier(binarySignatureIdentifier,
-                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                        zipArchiveIdentifier.identify(results.getUri(), request);
-                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("ISO", archiveConfiguration.getExpandArchiveTypes())) && ISO_9660.equals(puid)) {
-                        IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
-                                new IsoArchiveContainerIdentifier(binarySignatureIdentifier,
-                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                        isoArchiveContainerIdentifier.identify(results.getUri(), request);
-                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("7ZIP", archiveConfiguration.getExpandArchiveTypes())) && SEVEN_ZIP.equals(puid)) {
-                        SevenZipArchiveContainerIdentifier sevenZipArchiveContainerIdentifier =
-                                new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
-                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                        sevenZipArchiveContainerIdentifier.identify(results.getUri(), request);
-                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("BZIP2", archiveConfiguration.getExpandArchiveTypes())) && BZIP2_ARCHIVE.equals(puid)) {
-                        Bzip2ArchiveContentIdentifier bzip2ArchiveContentIdentifier =
-                                new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
-                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                        bzip2ArchiveContentIdentifier.identify(results.getUri(), request);
+                    switch (puid){
+                        case GZIP_ARCHIVE:
+                            if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("GZIP", archiveConfiguration.getExpandArchiveTypes()))) {
+                                GZipArchiveContentIdentifier gzipArchiveIdentifier =
+                                        new GZipArchiveContentIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                gzipArchiveIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
+                        case TAR_ARCHIVE:
+                            if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("TAR", archiveConfiguration.getExpandArchiveTypes()))) {
+                                TarArchiveContentIdentifier tarArchiveIdentifier =
+                                        new TarArchiveContentIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                tarArchiveIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
+                        case ZIP_ARCHIVE:
+//                        case JIP_ARCHIVE:
+                            if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive(ZIP, archiveConfiguration.getExpandArchiveTypes()))) {
+                                ZipArchiveContentIdentifier zipArchiveIdentifier =
+                                        new ZipArchiveContentIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                zipArchiveIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
+                        case ISO_9660:
+                            if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("ISO", archiveConfiguration.getExpandArchiveTypes()))) {
+                                IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
+                                        new IsoArchiveContainerIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                isoArchiveContainerIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
+                        case SEVEN_ZIP:
+                            if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("7ZIP", archiveConfiguration.getExpandArchiveTypes()))) {
+                                SevenZipArchiveContainerIdentifier sevenZipArchiveContainerIdentifier =
+                                        new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                sevenZipArchiveContainerIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
+                        case BZIP2_ARCHIVE:
+                            if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("BZIP2", archiveConfiguration.getExpandArchiveTypes()))) {
+                                Bzip2ArchiveContentIdentifier bzip2ArchiveContentIdentifier =
+                                        new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                bzip2ArchiveContentIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
+
+                        case ARC_ARCHIVE:
+                        case OTHERARC_ARCHIVE:
+                            if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("ARC", archiveConfiguration.getExpandWebArchiveTypes()))) {
+                                ArcArchiveContentIdentifier arcArchiveIdentifier =
+                                        new ArcArchiveContentIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                arcArchiveIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
+                        case WARC_ARCHIVE:
+                            if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("WARC", archiveConfiguration.getExpandWebArchiveTypes()))) {
+                                WarcArchiveContentIdentifier warcArchiveIdentifier =
+                                        new WarcArchiveContentIdentifier(binarySignatureIdentifier,
+                                                containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                                warcArchiveIdentifier.identify(results.getUri(), request);
+                            }
+                            break;
                     }
-                    if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("ARC", archiveConfiguration.getExpandWebArchiveTypes()))
-                            && (ARC_ARCHIVE.equals(puid) || OTHERARC_ARCHIVE.equals(puid))) {
-                        ArcArchiveContentIdentifier arcArchiveIdentifier =
-                                new ArcArchiveContentIdentifier(binarySignatureIdentifier,
-                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                        arcArchiveIdentifier.identify(results.getUri(), request);
-                    }
-                    if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("WARC", archiveConfiguration.getExpandWebArchiveTypes()))
-                        && (WARC_ARCHIVE.equals(puid))) {
-                        WarcArchiveContentIdentifier warcArchiveIdentifier =
-                                new WarcArchiveContentIdentifier(binarySignatureIdentifier,
-                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                        warcArchiveIdentifier.identify(results.getUri(), request);
-                    }
+
                 }
             }
         } else {

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -74,7 +74,7 @@ public class ResultPrinter {
     private static final String SPACE = " ";
 
     private static final String OLE2_CONTAINER = "OLE2";
-    private static final String ZIP_CONTAINER = "ZIP";
+    private static final String ZIP = "ZIP";
     private static final String ZIP_ARCHIVE = "x-fmt/263";
     private static final String JIP_ARCHIVE = "x-fmt/412";
     private static final String TAR_ARCHIVE = "x-fmt/265";
@@ -95,7 +95,6 @@ public class ResultPrinter {
     private String slash;
     private String slash1;
     private String wrongSlash;
-    private boolean archives;
     private ArchiveConfiguration archiveConfiguration;
 
     /**
@@ -105,12 +104,11 @@ public class ResultPrinter {
      * @param path                          current file/container path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param archives                      Should archives be examined?
      * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public ResultPrinter(final BinarySignatureIdentifier binarySignatureIdentifier,
                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                         final String path, final String slash, final String slash1, boolean archives, ArchiveConfiguration archiveConfiguration) {
+                         final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
 
         this.binarySignatureIdentifier = binarySignatureIdentifier;
         this.containerSignatureDefinitions = containerSignatureDefinitions;
@@ -118,7 +116,6 @@ public class ResultPrinter {
         this.slash = slash;
         this.slash1 = slash1;
         this.wrongSlash = this.slash.equals(R_SLASH) ? DOUBLE_SLASH : R_SLASH;
-        this.archives = archives;
         this.archiveConfiguration = archiveConfiguration;
         if (containerSignatureDefinitions != null) {
             triggerPuids = containerSignatureDefinitions.getTiggerPuids();
@@ -160,38 +157,36 @@ public class ResultPrinter {
                 }
                 System.out.println(fileName + "," + puid);
                 if (!container) {
-                    if (archives) {
-                        if (GZIP_ARCHIVE.equals(puid)) {
-                            GZipArchiveContentIdentifier gzipArchiveIdentifier =
-                                    new GZipArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                            gzipArchiveIdentifier.identify(results.getUri(), request);
-                        } else if (TAR_ARCHIVE.equals(puid)) {
-                            TarArchiveContentIdentifier tarArchiveIdentifier =
-                                    new TarArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                            tarArchiveIdentifier.identify(results.getUri(), request);
-                        } else if (ZIP_ARCHIVE.equals(puid) || JIP_ARCHIVE.equals(puid)) {
-                            ZipArchiveContentIdentifier zipArchiveIdentifier =
-                                    new ZipArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                            zipArchiveIdentifier.identify(results.getUri(), request);
-                        } else if (ISO_9660.equals(puid)) {
-                            IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
-                                    new IsoArchiveContainerIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                            isoArchiveContainerIdentifier.identify(results.getUri(), request);
-                        } else if (SEVEN_ZIP.equals(puid)) {
-                            SevenZipArchiveContainerIdentifier sevenZipArchiveContainerIdentifier =
-                                    new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                            sevenZipArchiveContainerIdentifier.identify(results.getUri(), request);
-                        } else if (BZIP2_ARCHIVE.equals(puid)) {
-                            Bzip2ArchiveContentIdentifier bzip2ArchiveContentIdentifier =
-                                    new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
-                                            containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
-                            bzip2ArchiveContentIdentifier.identify(results.getUri(), request);
-                        }
+                    if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("GZIP", archiveConfiguration.getExpandArchiveTypes())) && GZIP_ARCHIVE.equals(puid)) {
+                        GZipArchiveContentIdentifier gzipArchiveIdentifier =
+                                new GZipArchiveContentIdentifier(binarySignatureIdentifier,
+                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                        gzipArchiveIdentifier.identify(results.getUri(), request);
+                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("TAR", archiveConfiguration.getExpandArchiveTypes())) && TAR_ARCHIVE.equals(puid)) {
+                        TarArchiveContentIdentifier tarArchiveIdentifier =
+                                new TarArchiveContentIdentifier(binarySignatureIdentifier,
+                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                        tarArchiveIdentifier.identify(results.getUri(), request);
+                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive(ZIP, archiveConfiguration.getExpandArchiveTypes())) && ZIP_ARCHIVE.equals(puid) || JIP_ARCHIVE.equals(puid)) {
+                        ZipArchiveContentIdentifier zipArchiveIdentifier =
+                                new ZipArchiveContentIdentifier(binarySignatureIdentifier,
+                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                        zipArchiveIdentifier.identify(results.getUri(), request);
+                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("ISO", archiveConfiguration.getExpandArchiveTypes())) && ISO_9660.equals(puid)) {
+                        IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
+                                new IsoArchiveContainerIdentifier(binarySignatureIdentifier,
+                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                        isoArchiveContainerIdentifier.identify(results.getUri(), request);
+                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("7ZIP", archiveConfiguration.getExpandArchiveTypes())) && SEVEN_ZIP.equals(puid)) {
+                        SevenZipArchiveContainerIdentifier sevenZipArchiveContainerIdentifier =
+                                new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
+                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                        sevenZipArchiveContainerIdentifier.identify(results.getUri(), request);
+                    } else if ((archiveConfiguration.getExpandAllArchives() || containsCaseInsensitive("BZIP2", archiveConfiguration.getExpandArchiveTypes())) && BZIP2_ARCHIVE.equals(puid)) {
+                        Bzip2ArchiveContentIdentifier bzip2ArchiveContentIdentifier =
+                                new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
+                                        containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
+                        bzip2ArchiveContentIdentifier.identify(results.getUri(), request);
                     }
                 }
                 if ((archiveConfiguration.getExpandAllWebArchives() || containsCaseInsensitive("ARC", archiveConfiguration.getExpandWebArchiveTypes()))
@@ -252,7 +247,7 @@ public class ResultPrinter {
                             } catch (IOException e) {   // carry on after container i/o problems
                                 System.err.println(e + SPACE + L_BRACKET + fileName + R_BRACKET);
                             }
-                        } else if (ZIP_CONTAINER.equals(containerType)) {
+                        } else if (ZIP.equals(containerType)) {
                             try {
                                 ZipContainerContentIdentifier zipIdentifier =
                                             new ZipContainerContentIdentifier();

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -247,6 +247,7 @@ public class CommandFactoryImpl implements CommandFactory {
         command.setRecursive(cli.hasOption(CommandLineParam.RECURSIVE.toString()));
         command.setArchives(cli.hasOption(CommandLineParam.ARCHIVES.toString()));
         command.setWebArchives(cli.hasOption(CommandLineParam.WEB_ARCHIVES.toString()));
+        command.setWebArchiveTypes(cli.getOptionValues(CommandLineParam.WEB_ARCHIVE_TYPES.toString()));
         command.setExtensionFilter(extensions);
         command.setQuiet(cli.hasOption(CommandLineParam.QUIET.toString()));
 

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -245,9 +245,10 @@ public class CommandFactoryImpl implements CommandFactory {
         command.setSignatureFile(signatureFile);
         command.setContainerSignatureFile(containerSignatureFile);
         command.setRecursive(cli.hasOption(CommandLineParam.RECURSIVE.toString()));
-        command.setArchives(cli.hasOption(CommandLineParam.ARCHIVES.toString()));
+        command.setExpandAllArchives(cli.hasOption(CommandLineParam.ARCHIVES.toString()));
+        command.setExpandArchiveTypes(cli.getOptionValues(CommandLineParam.ARCHIVE_TYPES.toString()));
         command.setExpandAllWebArchives(cli.hasOption(CommandLineParam.WEB_ARCHIVES.toString()));
-        command.setWebArchiveTypes(cli.getOptionValues(CommandLineParam.WEB_ARCHIVE_TYPES.toString()));
+        command.setExpandWebArchiveTypes(cli.getOptionValues(CommandLineParam.WEB_ARCHIVE_TYPES.toString()));
         command.setExtensionFilter(extensions);
         command.setQuiet(cli.hasOption(CommandLineParam.QUIET.toString()));
 

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -246,7 +246,7 @@ public class CommandFactoryImpl implements CommandFactory {
         command.setContainerSignatureFile(containerSignatureFile);
         command.setRecursive(cli.hasOption(CommandLineParam.RECURSIVE.toString()));
         command.setArchives(cli.hasOption(CommandLineParam.ARCHIVES.toString()));
-        command.setWebArchives(cli.hasOption(CommandLineParam.WEB_ARCHIVES.toString()));
+        command.setExpandAllWebArchives(cli.hasOption(CommandLineParam.WEB_ARCHIVES.toString()));
         command.setWebArchiveTypes(cli.getOptionValues(CommandLineParam.WEB_ARCHIVE_TYPES.toString()));
         command.setExtensionFilter(extensions);
         command.setQuiet(cli.hasOption(CommandLineParam.QUIET.toString()));

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
@@ -449,7 +449,7 @@ public enum CommandLineParam {
     public static Options noProfileRunSubOptions() {
         Options options = new Options();
 
-        Arrays.asList(SIGNATURE_FILE, CONTAINER_SIGNATURE_FILE, EXTENSION_LIST, ARCHIVES, WEB_ARCHIVES, WEB_ARCHIVE_TYPES, RECURSIVE, QUIET).forEach(
+        Arrays.asList(SIGNATURE_FILE, CONTAINER_SIGNATURE_FILE, EXTENSION_LIST, ARCHIVES, ARCHIVE_TYPES, WEB_ARCHIVES, WEB_ARCHIVE_TYPES, RECURSIVE, QUIET).forEach(
                 option -> options.addOption(option.newOption())
         );
         return options;

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
@@ -212,7 +212,14 @@ public enum CommandLineParam {
     },
 
     /** Open archives flag. */
-    ARCHIVES("A", "open-archives", I18N.ARCHIVES_HELP) {
+    ARCHIVES("A", "open-all-archives", I18N.ARCHIVES_HELP) {
+        @Override
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
+            return null;
+        }
+    },
+    /** Open archive types. */
+    ARCHIVE_TYPES("At", "open-archive-types", true, -1, I18N.ARCHIVE_TYPES_HELP, "archive types") {
         @Override
         public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
@@ -396,6 +403,7 @@ public enum CommandLineParam {
         options.addOption(CONTAINER_SIGNATURE_FILE.newOption());
         options.addOption(EXTENSION_LIST.newOption());
         options.addOption(ARCHIVES.newOption());
+        options.addOption(ARCHIVE_TYPES.newOption());
         options.addOption(WEB_ARCHIVES.newOption());
         options.addOption(WEB_ARCHIVE_TYPES.newOption());
         options.addOption(RECURSIVE.newOption());

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
@@ -31,6 +31,7 @@
  */
 package uk.gov.nationalarchives.droid.command.action;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,34 +55,34 @@ public enum CommandLineParam {
             return commandFactory.getHelpCommand();
         }
     },
-    
+
     /** Version. */
     VERSION("v", "version", I18N.VERSION_HELP) {
         @Override
         public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return commandFactory.getVersionCommand();
         }
-    }, 
-    
+    },
+
     /** Export with one row per file. */
     EXPORT_ONE_ROW_PER_FILE("e", "export-file", false, 1, I18N.EXPORT_FILE_HELP, filename()) {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) 
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli)
             throws CommandLineSyntaxException {
             return commandFactory.getExportFileCommand(cli);
         }
     },
-    
+
     /** Export with one row per format. */
     EXPORT_ONE_ROW_PER_FORMAT("E", "export-format", false, 1, I18N.EXPORT_FORMAT_HELP, filename()) {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) 
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli)
             throws CommandLineSyntaxException {
             return commandFactory.getExportFormatCommand(cli);
         }
-    }, 
-    
-    
+    },
+
+
     /** List of profiles to be worked on. */
     PROFILES("p", "profile(s)", true, -1, I18N.PROFILES_HELP, "filename(s)") {
         @Override
@@ -89,7 +90,7 @@ public enum CommandLineParam {
             return null;
         }
     },
-    
+
     /** Narrow filter. */
     ALL_FILTER("f", "filter-all", true, -1, I18N.ALL_FILTER, filters()) {
         @Override
@@ -124,15 +125,15 @@ public enum CommandLineParam {
             throws CommandLineSyntaxException {
             return commandFactory.getReportCommand(cli);
         }
-    }, 
-    /** List of  report to be worked on. */    
+    },
+    /** List of  report to be worked on. */
     REPORT_NAME("n", "report-name", true, 1, I18N.REPORT_NAME_HELP, "report name") {
         @Override
         public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
         }
     },
-    
+
     /** Set the report output type. */
     REPORT_OUTPUT_TYPE("t", "report-type", true, 1, I18N.REPORT_TYPE_HELP, "report type") {
         @Override
@@ -140,7 +141,7 @@ public enum CommandLineParam {
             return null;
         }
     },
-    
+
     /** Lists the reports. */
     LIST_REPORTS("l", "list-reports", I18N.LIST_REPORTS_HELP) {
         @Override
@@ -148,8 +149,8 @@ public enum CommandLineParam {
                 CommandLine cli) {
             return commandFactory.getListReportCommand();
         }
-    },    
-    
+    },
+
     /** Lists the filter fields. */
     LIST_FILTER_FIELD("k", "filter-fields", I18N.LIST_FILTER_FIELD) {
         @Override
@@ -158,7 +159,7 @@ public enum CommandLineParam {
             return commandFactory.getFilterFieldCommand();
         }
     },
-    
+
     /** Runs a profile with the specified resources. */
     RUN_PROFILE("a", "profile-resources", true, -1, I18N.RUN_PROFILE_HELP, "resources") {
         @Override
@@ -167,7 +168,7 @@ public enum CommandLineParam {
             return commandFactory.getProfileCommand(cli);
         }
     },
-    
+
     /** Runs without a profile and with the specified resources. */
     RUN_NO_PROFILE("Nr", "no-profile-resource", true, -1, I18N.RUN_NO_PROFILE_HELP, "folder") {
         @Override
@@ -176,7 +177,7 @@ public enum CommandLineParam {
             return commandFactory.getNoProfileCommand(cli);
         }
     },
-    
+
     /** Signature file. */
     SIGNATURE_FILE("Ns", "signature-file", true, 1, I18N.SIGNATURE_FILE_HELP, filename()) {
         @Override
@@ -184,7 +185,7 @@ public enum CommandLineParam {
             return null;
         }
     },
-    
+
     /** Container signature file. */
     CONTAINER_SIGNATURE_FILE("Nc", "container-file", true, 1,
             I18N.CONTAINER_SIGNATURE_FILE_HELP, filename()) {
@@ -193,7 +194,7 @@ public enum CommandLineParam {
             return null;
         }
     },
-    
+
     /** Extensions to match. */
     EXTENSION_LIST("Nx", "extension-list", true, -1, I18N.EXTENSION_LIST_HELP, "extensions") {
         @Override
@@ -201,7 +202,7 @@ public enum CommandLineParam {
             return null;
         }
     },
-    
+
     /** Recursive operation flag. */
     RECURSIVE("R", "recurse", I18N.RECURSE_HELP) {
         @Override
@@ -209,7 +210,7 @@ public enum CommandLineParam {
             return null;
         }
     },
-    
+
     /** Open archives flag. */
     ARCHIVES("A", "open-archives", I18N.ARCHIVES_HELP) {
         @Override
@@ -217,8 +218,15 @@ public enum CommandLineParam {
             return null;
         }
     },
-    /** Open webarchives flag. */
-    WEB_ARCHIVES("W", "open-webarchives", I18N.WEB_ARCHIVES_HELP) {
+    /** Open all webarchives flag. */
+    WEB_ARCHIVES("W", "open-all-webarchives", I18N.WEB_ARCHIVES_HELP) {
+        @Override
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
+            return null;
+        }
+    },
+    /** Open webarchive types. */
+    WEB_ARCHIVE_TYPES("Wt", "open-webarchive-types", true, 2, I18N.WEB_ARCHIVE_TYPES_HELP, "web archive types") {
         @Override
         public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
@@ -232,7 +240,7 @@ public enum CommandLineParam {
             return null;
         }
     },
-    
+
     /** Check for signature updates. */
     CHECK_SIGNATURE_UPDATE("c", "check-signature-update", I18N.CHECK_SIGNATURE_UPDATE_HELP) {
         @Override
@@ -240,7 +248,7 @@ public enum CommandLineParam {
             return commandFactory.getCheckSignatureUpdateCommand();
         }
     },
-    
+
     /** Download latest signature update. */
     DOWNLOAD_SIGNATURE_UPDATE("d", "download-signature-update", I18N.DOWNLOAD_SIGNATURE_UPDATE_HELP) {
         @Override
@@ -248,7 +256,7 @@ public enum CommandLineParam {
             return commandFactory.getDownloadSignatureUpdateCommand();
         }
     },
-    
+
     /** List all signature files. */
     LIST_SIGNATURE_VERSIONS("X", "list-signature-files", I18N.LIST_SIGNATURE_VERSIONS_HELP) {
         @Override
@@ -256,7 +264,7 @@ public enum CommandLineParam {
             return commandFactory.getListAllSignatureVersionsCommand();
         }
     },
-    
+
 
     /** Display the default signature update. */
     DEFAULT_SIGNATURE_VERSION("x", "display-signature-file", I18N.DEFAULT_SIGNATURE_VERSION_HELP) {
@@ -270,7 +278,7 @@ public enum CommandLineParam {
     CONFIGURE_DEFAULT_SIGNATURE_VERSION("s", "set-signature-file", true, 1,
             I18N.CONFIGURE_DEFAULT_SIGNATURE_VERSION_HELP, I18N.getResource(I18N.VERSION)) {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) 
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli)
             throws CommandLineException {
             return commandFactory.getConfigureDefaultSignatureVersionCommand(cli);
         }
@@ -280,7 +288,7 @@ public enum CommandLineParam {
      * All the top-level command line options.
      */
     public static final Map<String, CommandLineParam> TOP_LEVEL_COMMANDS = new HashMap<String, CommandLineParam>();
-    
+
     static {
         addTopLevelCommand(HELP);
         addTopLevelCommand(VERSION);
@@ -299,47 +307,47 @@ public enum CommandLineParam {
     }
 
     private static final String FILENAME = "filename";
-    
+
     private String shortName;
     private String longName;
     private String resourceKey;
     private boolean argsRequired;
     private int maxArgs;
     private String argName;
-    
-    
-    private CommandLineParam(String shortName, String longName, String resourceKey) { 
+
+
+    private CommandLineParam(String shortName, String longName, String resourceKey) {
         this.shortName = shortName;
         this.longName = longName;
         this.resourceKey = resourceKey;
     }
-    
-    private CommandLineParam(String shortName, String longName, boolean argsRequired, 
-            int maxArgs, String resourceKey, String argName) { 
+
+    private CommandLineParam(String shortName, String longName, boolean argsRequired,
+            int maxArgs, String resourceKey, String argName) {
         this(shortName, longName, resourceKey);
         this.maxArgs = maxArgs;
         this.argName = argName;
         this.argsRequired = argsRequired;
     }
-    
+
     private static String filename() {
         return FILENAME;
     }
-    
+
     private static void addTopLevelCommand(CommandLineParam command) {
         TOP_LEVEL_COMMANDS.put(command.toString(), command);
     }
-    
+
     /**
      * Gets a droid command for this command line option.
      * @param commandFactory the command factory
      * @param cli the command line
-     * @throws CommandLineException command parse exception. 
+     * @throws CommandLineException command parse exception.
      * @return a droid command.
      */
     public abstract DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli)
         throws CommandLineException;
-    
+
     /**
      * {@inheritDoc}
      */
@@ -349,7 +357,7 @@ public enum CommandLineParam {
     }
 
     /**
-     * 
+     *
      * @return a new option for the parameter.
      */
     Option newOption() {
@@ -359,28 +367,28 @@ public enum CommandLineParam {
             option.setOptionalArg(!argsRequired);
         }
         option.setArgName(argName);
-        
+
         return option;
     }
-    
-    
+
+
     private static String filters() {
         return "filter ...";
     }
-    
+
     /**
      * All options.
      * @return all options
      */
     public static Options options() {
         Options options = new Options();
-        
+
         OptionGroup topGroup = new OptionGroup();
 
         for (CommandLineParam param : TOP_LEVEL_COMMANDS.values()) {
             topGroup.addOption(param.newOption());
         }
-        
+
         options.addOption(PROFILES.newOption());
         options.addOption(REPORT_NAME.newOption());
         options.addOption(REPORT_OUTPUT_TYPE.newOption());
@@ -389,29 +397,30 @@ public enum CommandLineParam {
         options.addOption(EXTENSION_LIST.newOption());
         options.addOption(ARCHIVES.newOption());
         options.addOption(WEB_ARCHIVES.newOption());
+        options.addOption(WEB_ARCHIVE_TYPES.newOption());
         options.addOption(RECURSIVE.newOption());
         options.addOption(QUIET.newOption());
         options.addOption(BOM.newOption());
-        
+
         OptionGroup filterOptions = new OptionGroup();
         filterOptions.addOption(ALL_FILTER.newOption());
         filterOptions.addOption(ANY_FILTER.newOption());
-        
+
         options.addOptionGroup(filterOptions);
         options.addOptionGroup(topGroup);
-        
+
         return options;
 
     }
-    
+
     /**
      * Single Options.
-     * 
+     *
      * @return the Single Options
      */
     public static Options singleOptions() {
         Options options = new Options();
-        
+
         options.addOption(CHECK_SIGNATURE_UPDATE.newOption());
         options.addOption(DOWNLOAD_SIGNATURE_UPDATE.newOption());
         options.addOption(HELP.newOption());
@@ -420,85 +429,80 @@ public enum CommandLineParam {
         options.addOption(VERSION.newOption());
         options.addOption(DEFAULT_SIGNATURE_VERSION.newOption());
         options.addOption(LIST_SIGNATURE_VERSIONS.newOption());
-        
+
         return options;
     }
-    
+
     /**
      * No Profile Run sub-options.
-     * 
+     *
      * @return sub-options for no-profile run
      */
     public static Options noProfileRunSubOptions() {
         Options options = new Options();
-        
-        options.addOption(SIGNATURE_FILE.newOption());
-        options.addOption(CONTAINER_SIGNATURE_FILE.newOption());
-        options.addOption(EXTENSION_LIST.newOption());
-        options.addOption(ARCHIVES.newOption());
-        options.addOption(WEB_ARCHIVES.newOption());
-        options.addOption(RECURSIVE.newOption());
-        options.addOption(QUIET.newOption());
-        
+
+        Arrays.asList(SIGNATURE_FILE, CONTAINER_SIGNATURE_FILE, EXTENSION_LIST, ARCHIVES, WEB_ARCHIVES, WEB_ARCHIVE_TYPES, RECURSIVE, QUIET).forEach(
+                option -> options.addOption(option.newOption())
+        );
         return options;
     }
-    
+
     /**
      * Profile Run sub-options.
-     * 
+     *
      * @return sub-options for profile run
      */
     public static Options profileRunSubOptions() {
         Options options = new Options();
-        
+
         options.addOption(PROFILES.newOption());
         options.addOption(RECURSIVE.newOption());
         options.addOption(QUIET.newOption());
-        
+
         return options;
     }
-    
+
     /**
      * Export sub-options.
-     * 
+     *
      * @return sub-options for Export
      */
     public static Options exportSubOptions() {
         Options options = new Options();
-        
+
         options.addOption(PROFILES.newOption());
         options.addOption(ANY_FILTER.newOption());
         options.addOption(ALL_FILTER.newOption());
         options.addOption(BOM.newOption());
-        
+
         return options;
     }
-    
+
     /**
      * Report sub-options.
-     * 
+     *
      * @return sub-options for Report
      */
     public static Options reportSubOptions() {
         Options options = new Options();
-        
+
         options.addOption(PROFILES.newOption());
         options.addOption(REPORT_NAME.newOption());
         options.addOption(REPORT_OUTPUT_TYPE.newOption());
-        
+
         return options;
     }
-    
+
     /**
      * Gets Options from Command Line parameter.
-     * 
+     *
      * @param commandLineParam The command line parameter
-     * 
+     *
      * @return options for Command Line parameter
      */
     public static Options getOptions(final CommandLineParam commandLineParam) {
         Options options = new Options();
-        
+
         options.addOption(commandLineParam.newOption());
         return options;
     }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -89,9 +89,10 @@ public class NoProfileRunCommand implements DroidCommand {
     private int maxBytesToScan = -1;
     private boolean quietFlag;
     private boolean recursive;
-    private boolean archives;
+    private boolean expandAllArchives;
+    private String[] expandArchiveTypes;
     private boolean expandAllWebArchives;
-    private String[] webArchiveTypes;
+    private String[] expandWebArchiveTypes;
 
     private Logger log = LoggerFactory.getLogger(this.getClass());
 
@@ -179,7 +180,7 @@ public class NoProfileRunCommand implements DroidCommand {
         path = "";
         ResultPrinter resultPrinter =
             new ResultPrinter(binarySignatureIdentifier, containerSignatureDefinitions,
-                path, slash, slash, archives, new ArchiveConfiguration(expandAllWebArchives, webArchiveTypes));
+                path, slash, slash, new ArchiveConfiguration(expandAllArchives, expandArchiveTypes, expandAllWebArchives, expandWebArchiveTypes));
 
         for (final Path file : matchedFiles) {
             final String fileName = file.toAbsolutePath().toString();
@@ -243,9 +244,10 @@ public class NoProfileRunCommand implements DroidCommand {
             }
         }
         
-        System.out.println("Open archives: " + (this.archives ? PRINTABLE_ALL : PRINTABLE_NONE));
+        System.out.println("Open archives: " + (this.expandAllArchives ? PRINTABLE_ALL :
+                (this.expandArchiveTypes!=null && this.expandArchiveTypes.length>0 ? String.join(", ", this.expandArchiveTypes) : PRINTABLE_NONE)));
         System.out.println("Open web archives: " + (this.expandAllWebArchives ? PRINTABLE_ALL :
-                (this.webArchiveTypes!=null && this.webArchiveTypes.length>0 ? String.join(", ", this.webArchiveTypes) : PRINTABLE_NONE)));
+                (this.expandWebArchiveTypes !=null && this.expandWebArchiveTypes.length>0 ? String.join(", ", this.expandWebArchiveTypes) : PRINTABLE_NONE)));
     }
     //CHECKSTYLE:ON
     /**
@@ -273,15 +275,6 @@ public class NoProfileRunCommand implements DroidCommand {
      */
     public void setContainerSignatureFile(final String containerSignatureFile) {
         this.containerSignaturesFileName = containerSignatureFile;
-    }
-    
-    /**
-     * Set whether this examines Archives.
-     * 
-     * @param archives true if we should examine archives, false otherwise
-     */
-    public void setArchives(boolean archives) {
-        this.archives = archives;
     }
 
     /**
@@ -323,10 +316,26 @@ public class NoProfileRunCommand implements DroidCommand {
 
     /**
      *
-     * @param webArchiveTypes       list of web archive types to expand
+     * @param expandWebArchiveTypes       list of web archive types to expand
      */
-    public void setWebArchiveTypes(String[] webArchiveTypes) {
-        this.webArchiveTypes = webArchiveTypes;
+    public void setExpandWebArchiveTypes(String[] expandWebArchiveTypes) {
+        this.expandWebArchiveTypes = expandWebArchiveTypes;
     }
 
+    /**
+     * Set whether this examines Archives.
+     *
+     * @param expandAllArchives true if we should examine archives, false otherwise
+     */
+    public void setExpandAllArchives(boolean expandAllArchives) {
+        this.expandAllArchives = expandAllArchives;
+    }
+
+    /**
+     *
+     * @param expandArchiveTypes       list of web archive types to expand
+     */
+    public void setExpandArchiveTypes(String[] expandArchiveTypes) {
+        this.expandArchiveTypes = expandArchiveTypes;
+    }
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -47,6 +47,7 @@ import java.util.ResourceBundle;
 
 import javax.xml.bind.JAXBException;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,9 @@ public class NoProfileRunCommand implements DroidCommand {
     private static final String BACKWARD_SLASH = "\\";
     private static final String PRINTABLE_TRUE = "True";
     private static final String PRINTABLE_FALSE = "False";
-    
+    private static final String PRINTABLE_ALL = "All";
+    private static final String PRINTABLE_NONE = "None";
+
     private String fileSignaturesFileName;
     private String containerSignaturesFileName;
     private String[] resources;
@@ -89,6 +92,7 @@ public class NoProfileRunCommand implements DroidCommand {
     private boolean archives;
     private boolean webArchives;
     private Logger log = LoggerFactory.getLogger(this.getClass());
+    private String[] webArchiveTypes;
 
     //CHECKSTYLE:OFF
     /**
@@ -174,7 +178,7 @@ public class NoProfileRunCommand implements DroidCommand {
         path = "";
         ResultPrinter resultPrinter =
             new ResultPrinter(binarySignatureIdentifier, containerSignatureDefinitions,
-                path, slash, slash, archives, webArchives);
+                path, slash, slash, archives, webArchives, webArchiveTypes);
 
         for (final Path file : matchedFiles) {
             final String fileName = file.toAbsolutePath().toString();
@@ -238,8 +242,9 @@ public class NoProfileRunCommand implements DroidCommand {
             }
         }
         
-        System.out.println("Open archives: " + (this.archives ? PRINTABLE_TRUE : PRINTABLE_FALSE));
-        System.out.println("Open web archives: " + (this.webArchives ? PRINTABLE_TRUE : PRINTABLE_FALSE));
+        System.out.println("Open archives: " + (this.archives ? PRINTABLE_ALL : PRINTABLE_NONE));
+        System.out.println("Open web archives: " + (this.webArchives ? PRINTABLE_ALL :
+                (this.webArchiveTypes.length>0 ? String.join(", ", this.webArchiveTypes) : PRINTABLE_NONE)));
     }
     //CHECKSTYLE:ON
     /**
@@ -313,4 +318,13 @@ public class NoProfileRunCommand implements DroidCommand {
     public void setQuiet(final boolean quiet) {
         this.quietFlag = quiet;
     }
+
+    /**
+     *
+     * @param webArchiveTypes       list of web archive types to examine
+     */
+    public void setWebArchiveTypes(String[] webArchiveTypes) {
+        this.webArchiveTypes = webArchiveTypes;
+    }
+
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -47,11 +47,11 @@ import java.util.ResourceBundle;
 
 import javax.xml.bind.JAXBException;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.gov.nationalarchives.droid.command.ResultPrinter;
+import uk.gov.nationalarchives.droid.command.archive.ArchiveConfiguration;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureDefinitions;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureSaxParser;
 import uk.gov.nationalarchives.droid.core.BinarySignatureIdentifier;
@@ -91,8 +91,9 @@ public class NoProfileRunCommand implements DroidCommand {
     private boolean recursive;
     private boolean archives;
     private boolean expandAllWebArchives;
-    private Logger log = LoggerFactory.getLogger(this.getClass());
     private String[] webArchiveTypes;
+
+    private Logger log = LoggerFactory.getLogger(this.getClass());
 
     //CHECKSTYLE:OFF
     /**
@@ -178,7 +179,7 @@ public class NoProfileRunCommand implements DroidCommand {
         path = "";
         ResultPrinter resultPrinter =
             new ResultPrinter(binarySignatureIdentifier, containerSignatureDefinitions,
-                path, slash, slash, archives, expandAllWebArchives, webArchiveTypes);
+                path, slash, slash, archives, new ArchiveConfiguration(expandAllWebArchives, webArchiveTypes));
 
         for (final Path file : matchedFiles) {
             final String fileName = file.toAbsolutePath().toString();
@@ -244,7 +245,7 @@ public class NoProfileRunCommand implements DroidCommand {
         
         System.out.println("Open archives: " + (this.archives ? PRINTABLE_ALL : PRINTABLE_NONE));
         System.out.println("Open web archives: " + (this.expandAllWebArchives ? PRINTABLE_ALL :
-                (this.webArchiveTypes.length>0 ? String.join(", ", this.webArchiveTypes) : PRINTABLE_NONE)));
+                (this.webArchiveTypes!=null && this.webArchiveTypes.length>0 ? String.join(", ", this.webArchiveTypes) : PRINTABLE_NONE)));
     }
     //CHECKSTYLE:ON
     /**
@@ -288,9 +289,10 @@ public class NoProfileRunCommand implements DroidCommand {
      *
      * @param expandAllWebArchives true if we should examine web archives, false otherwise
      */
-    public void setWebArchives(boolean expandAllWebArchives) {
+    public void setExpandAllWebArchives(boolean expandAllWebArchives) {
         this.expandAllWebArchives = expandAllWebArchives;
     }
+
     /**
      * Set recursive.
      * 
@@ -321,7 +323,7 @@ public class NoProfileRunCommand implements DroidCommand {
 
     /**
      *
-     * @param webArchiveTypes       list of web archive types to examine
+     * @param webArchiveTypes       list of web archive types to expand
      */
     public void setWebArchiveTypes(String[] webArchiveTypes) {
         this.webArchiveTypes = webArchiveTypes;

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -90,7 +90,7 @@ public class NoProfileRunCommand implements DroidCommand {
     private boolean quietFlag;
     private boolean recursive;
     private boolean archives;
-    private boolean webArchives;
+    private boolean expandAllWebArchives;
     private Logger log = LoggerFactory.getLogger(this.getClass());
     private String[] webArchiveTypes;
 
@@ -178,7 +178,7 @@ public class NoProfileRunCommand implements DroidCommand {
         path = "";
         ResultPrinter resultPrinter =
             new ResultPrinter(binarySignatureIdentifier, containerSignatureDefinitions,
-                path, slash, slash, archives, webArchives, webArchiveTypes);
+                path, slash, slash, archives, expandAllWebArchives, webArchiveTypes);
 
         for (final Path file : matchedFiles) {
             final String fileName = file.toAbsolutePath().toString();
@@ -243,7 +243,7 @@ public class NoProfileRunCommand implements DroidCommand {
         }
         
         System.out.println("Open archives: " + (this.archives ? PRINTABLE_ALL : PRINTABLE_NONE));
-        System.out.println("Open web archives: " + (this.webArchives ? PRINTABLE_ALL :
+        System.out.println("Open web archives: " + (this.expandAllWebArchives ? PRINTABLE_ALL :
                 (this.webArchiveTypes.length>0 ? String.join(", ", this.webArchiveTypes) : PRINTABLE_NONE)));
     }
     //CHECKSTYLE:ON
@@ -286,10 +286,10 @@ public class NoProfileRunCommand implements DroidCommand {
     /**
      * Set whether this examines Web Archives.
      *
-     * @param webArchives true if we should examine web archives, false otherwise
+     * @param expandAllWebArchives true if we should examine web archives, false otherwise
      */
-    public void setWebArchives(boolean webArchives) {
-        this.webArchives = webArchives;
+    public void setWebArchives(boolean expandAllWebArchives) {
+        this.expandAllWebArchives = expandAllWebArchives;
     }
     /**
      * Set recursive.

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifier.java
@@ -59,18 +59,19 @@ import uk.gov.nationalarchives.droid.core.interfaces.resource.RequestMetaData;
 public class ArcArchiveContentIdentifier extends ArchiveContentIdentifier {
 
     /**
-     * 
-     * @param binarySignatureIdentifier     binary signature identifier
+     *  @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
-     * @param path                          current archive path 
+     * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         optional list of web archive types to examine
      */
     public ArcArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
-            final ContainerSignatureDefinitions containerSignatureDefinitions,
-            final String path, final String slash, final String slash1) {
+                                       final ContainerSignatureDefinitions containerSignatureDefinitions,
+                                       final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, false);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifier.java
@@ -64,14 +64,12 @@ public class ArcArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         optional list of web archive types to examine
-     */
+     * @param archiveConfiguration          configuration to expand archives and web archives     */
     public ArcArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                        final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                       final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                       final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifier.java
@@ -64,14 +64,14 @@ public class ArcArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         optional list of web archive types to examine
      */
     public ArcArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                        final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                       final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                       final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveConfiguration.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveConfiguration.java
@@ -35,15 +35,21 @@ package uk.gov.nationalarchives.droid.command.archive;
  * configuration to expand web archives and archives.
  */
 public class ArchiveConfiguration {
+    private Boolean expandAllArchives;
+    private String[] expandArchiveTypes;
     private Boolean expandAllWebArchives;
     private String[] expandWebArchiveTypes;
 
     /**
      *
+     * @param expandAllArchives whether to expand all archives
+     * @param expandArchiveTypes list of archive types to expand
      * @param expandAllWebArchives whether to expand all web archives
      * @param expandWebArchiveTypes list of web archive types to expand
      */
-    public ArchiveConfiguration(Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+    public ArchiveConfiguration(Boolean expandAllArchives, String[] expandArchiveTypes, Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+        this.expandAllArchives = expandAllArchives;
+        this.expandArchiveTypes = expandArchiveTypes;
         this.expandAllWebArchives = expandAllWebArchives;
         this.expandWebArchiveTypes = expandWebArchiveTypes;
     }
@@ -76,5 +82,33 @@ public class ArchiveConfiguration {
      */
     public void setExpandWebArchiveTypes(String[] expandWebArchiveTypes) {
         this.expandWebArchiveTypes = expandWebArchiveTypes;
+    }
+
+    /**
+     * @return whether to expand all archives
+     */
+    public Boolean getExpandAllArchives() {
+        return expandAllArchives;
+    }
+    /**
+     * @param expandAllArchives whether to expand all archives
+     */
+    public void setExpandAllArchives(Boolean expandAllArchives) {
+        this.expandAllArchives = expandAllArchives;
+    }
+
+    /**
+     *
+     * @return list of archive types to expand
+     */
+    public String[] getExpandArchiveTypes() {
+        return expandArchiveTypes;
+    }
+    /**
+     *
+     * @param expandArchiveTypes list of archive types to expand
+     */
+    public void setExpandArchiveTypes(String[] expandArchiveTypes) {
+        this.expandArchiveTypes = expandArchiveTypes;
     }
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveConfiguration.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveConfiguration.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.gov.nationalarchives.droid.command.archive;
+
+/**
+ * configuration to expand web archives and archives.
+ */
+public class ArchiveConfiguration {
+    private Boolean expandAllWebArchives;
+    private String[] expandWebArchiveTypes;
+
+    /**
+     *
+     * @param expandAllWebArchives whether to expand all web archives
+     * @param expandWebArchiveTypes list of web archive types to expand
+     */
+    public ArchiveConfiguration(Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+        this.expandAllWebArchives = expandAllWebArchives;
+        this.expandWebArchiveTypes = expandWebArchiveTypes;
+    }
+
+    /**
+     * @return whether to expand all web archives
+     */
+    public Boolean getExpandAllWebArchives() {
+        return expandAllWebArchives;
+    }
+
+    /**
+     * @param expandAllWebArchives whether to expand all web archives
+     */
+    public void setExpandAllWebArchives(Boolean expandAllWebArchives) {
+        this.expandAllWebArchives = expandAllWebArchives;
+    }
+
+    /**
+     *
+     * @return list of web archive types to expand
+     */
+    public String[] getExpandWebArchiveTypes() {
+        return expandWebArchiveTypes;
+    }
+
+    /**
+     *
+     * @param expandWebArchiveTypes list of web archive types to expand
+     */
+    public void setExpandWebArchiveTypes(String[] expandWebArchiveTypes) {
+        this.expandWebArchiveTypes = expandWebArchiveTypes;
+    }
+}

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveConfiguration.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
@@ -58,9 +58,7 @@ public abstract class ArchiveContentIdentifier {
     protected ContainerSignatureDefinitions containerSignatureDefinitions;
     protected Path tmpDir;
     protected String path;
-    // CHECKSTYLE:ON
-    private Boolean expandAllWebArchives;
-    private String[] expandWebArchiveTypes;
+    private ArchiveConfiguration archiveConfiguration;
 
     /**
      * Initialization of instance values must be explicitly called by all children.
@@ -69,13 +67,12 @@ public abstract class ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives             optionally expand (W)ARC files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public ArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                     final ContainerSignatureDefinitions containerSignatureDefinitions,
                                     final String path, final String slash, final String slash1,
-                                    final Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                    final ArchiveConfiguration archiveConfiguration) {
 
         synchronized (this) {
             setBinarySignatureIdentifier(binarySignatureIdentifier);
@@ -83,8 +80,7 @@ public abstract class ArchiveContentIdentifier {
             setPath(path);
             setSlash(slash);
             setSlash1(slash1);
-            setExpandAllWebArchives(expandAllWebArchives);
-            setExpandWebArchiveTypes(expandWebArchiveTypes);
+            setArchiveConfiguration(archiveConfiguration);
             if (getTmpDir() == null) {
                 setTmpDir(Paths.get(System.getProperty("java.io.tmpdir")));
             }
@@ -163,18 +159,6 @@ public abstract class ArchiveContentIdentifier {
     protected void setPath(String path) {
         this.path = path;
     }
-    /**
-     * @return whether to expand (W)ARCs
-     */
-    protected Boolean getExpandAllWebArchives() {
-        return expandAllWebArchives;
-    }
-    /**
-     * @param ewa whether to expand (W)ARCs
-     */
-    protected void setExpandAllWebArchives(Boolean ewa) {
-        this.expandAllWebArchives = ewa;
-    }
 
     /**
      *
@@ -202,7 +186,7 @@ public abstract class ArchiveContentIdentifier {
             // CHECKSTYLE:OFF
             final ResultPrinter resultPrinter =
                     new ResultPrinter(getBinarySignatureIdentifier(),
-                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true, getExpandAllWebArchives(), getExpandWebArchiveTypes());
+                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true, getArchiveConfiguration());
             // CHECKSTYLE:ON
             resultPrinter.print(results, request);
             request.close();
@@ -220,17 +204,18 @@ public abstract class ArchiveContentIdentifier {
     }
 
     /**
-     * @return                          list of web archive types to examine
+     *
+     * @return configuration to expand web archives and archives
      */
-    public String[] getExpandWebArchiveTypes() {
-        return expandWebArchiveTypes;
+    public ArchiveConfiguration getArchiveConfiguration() {
+        return archiveConfiguration;
     }
 
     /**
      *
-     * @param expandWebArchiveTypes     list of web archive types to examine
+     * @param archiveConfiguration configuration to expand web archives and archives
      */
-    public void setExpandWebArchiveTypes(String[] expandWebArchiveTypes) {
-        this.expandWebArchiveTypes = expandWebArchiveTypes;
+    public void setArchiveConfiguration(ArchiveConfiguration archiveConfiguration) {
+        this.archiveConfiguration = archiveConfiguration;
     }
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
@@ -60,6 +60,7 @@ public abstract class ArchiveContentIdentifier {
     protected String path;
     // CHECKSTYLE:ON
     private Boolean expandWebArchives;
+    private String[] expandWebArchiveTypes;
 
     /**
      * Initialization of instance values must be explicitly called by all children.
@@ -69,11 +70,12 @@ public abstract class ArchiveContentIdentifier {
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
      * @param expandWebArchives             optionally expand (W)ARC files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public ArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
-                                       final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                       final String path, final String slash, final String slash1,
-                                       final Boolean expandWebArchives) {
+                                    final ContainerSignatureDefinitions containerSignatureDefinitions,
+                                    final String path, final String slash, final String slash1,
+                                    final Boolean expandWebArchives, String[] expandWebArchiveTypes) {
 
         synchronized (this) {
             setBinarySignatureIdentifier(binarySignatureIdentifier);
@@ -82,6 +84,7 @@ public abstract class ArchiveContentIdentifier {
             setSlash(slash);
             setSlash1(slash1);
             setExpandWebArchives(expandWebArchives);
+            setExpandWebArchiveTypes(expandWebArchiveTypes);
             if (getTmpDir() == null) {
                 setTmpDir(Paths.get(System.getProperty("java.io.tmpdir")));
             }
@@ -199,7 +202,7 @@ public abstract class ArchiveContentIdentifier {
             // CHECKSTYLE:OFF
             final ResultPrinter resultPrinter =
                     new ResultPrinter(getBinarySignatureIdentifier(),
-                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true, getExpandWebArchives());
+                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true, getExpandWebArchives(), getExpandWebArchiveTypes());
             // CHECKSTYLE:ON
             resultPrinter.print(results, request);
             request.close();
@@ -216,4 +219,18 @@ public abstract class ArchiveContentIdentifier {
         }
     }
 
+    /**
+     * @return                          list of web archive types to examine
+     */
+    public String[] getExpandWebArchiveTypes() {
+        return expandWebArchiveTypes;
+    }
+
+    /**
+     *
+     * @param expandWebArchiveTypes     list of web archive types to examine
+     */
+    public void setExpandWebArchiveTypes(String[] expandWebArchiveTypes) {
+        this.expandWebArchiveTypes = expandWebArchiveTypes;
+    }
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
@@ -186,7 +186,7 @@ public abstract class ArchiveContentIdentifier {
             // CHECKSTYLE:OFF
             final ResultPrinter resultPrinter =
                     new ResultPrinter(getBinarySignatureIdentifier(),
-                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true, getArchiveConfiguration());
+                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), getArchiveConfiguration());
             // CHECKSTYLE:ON
             resultPrinter.print(results, request);
             request.close();

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
@@ -59,7 +59,7 @@ public abstract class ArchiveContentIdentifier {
     protected Path tmpDir;
     protected String path;
     // CHECKSTYLE:ON
-    private Boolean expandWebArchives;
+    private Boolean expandAllWebArchives;
     private String[] expandWebArchiveTypes;
 
     /**
@@ -69,13 +69,13 @@ public abstract class ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand (W)ARC files
+     * @param expandAllWebArchives             optionally expand (W)ARC files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public ArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                     final ContainerSignatureDefinitions containerSignatureDefinitions,
                                     final String path, final String slash, final String slash1,
-                                    final Boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                    final Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
 
         synchronized (this) {
             setBinarySignatureIdentifier(binarySignatureIdentifier);
@@ -83,7 +83,7 @@ public abstract class ArchiveContentIdentifier {
             setPath(path);
             setSlash(slash);
             setSlash1(slash1);
-            setExpandWebArchives(expandWebArchives);
+            setExpandAllWebArchives(expandAllWebArchives);
             setExpandWebArchiveTypes(expandWebArchiveTypes);
             if (getTmpDir() == null) {
                 setTmpDir(Paths.get(System.getProperty("java.io.tmpdir")));
@@ -166,14 +166,14 @@ public abstract class ArchiveContentIdentifier {
     /**
      * @return whether to expand (W)ARCs
      */
-    protected Boolean getExpandWebArchives() {
-        return expandWebArchives;
+    protected Boolean getExpandAllWebArchives() {
+        return expandAllWebArchives;
     }
     /**
      * @param ewa whether to expand (W)ARCs
      */
-    protected void setExpandWebArchives(Boolean ewa) {
-        this.expandWebArchives = ewa;
+    protected void setExpandAllWebArchives(Boolean ewa) {
+        this.expandAllWebArchives = ewa;
     }
 
     /**
@@ -202,7 +202,7 @@ public abstract class ArchiveContentIdentifier {
             // CHECKSTYLE:OFF
             final ResultPrinter resultPrinter =
                     new ResultPrinter(getBinarySignatureIdentifier(),
-                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true, getExpandWebArchives(), getExpandWebArchiveTypes());
+                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true, getExpandAllWebArchives(), getExpandWebArchiveTypes());
             // CHECKSTYLE:ON
             resultPrinter.print(results, request);
             request.close();

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
@@ -66,14 +66,15 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param webArchives                   Whether to further expand gzipped web archive files
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public Bzip2ArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, final Boolean webArchives) {
+                                         final String path, final String slash, final String slash1, final Boolean expandWebArchives, String[] expandWebArchiveTypes) {
 
        super(binarySignatureIdentifier, containerSignatureDefinitions, path,
-            slash, slash1, webArchives);
+            slash, slash1, expandWebArchives, expandWebArchiveTypes);
 
     }
 
@@ -104,7 +105,7 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
                     binarySignatureIdentifier.matchBinarySignatures(bzRequest);
 
             final ResultPrinter resultPrinter = new ResultPrinter(binarySignatureIdentifier,
-                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandWebArchives());
+                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandWebArchives(), super.getExpandWebArchiveTypes());
             resultPrinter.print(bzResults, bzRequest);
         } catch (IOException ioe) {
             System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
@@ -66,15 +66,14 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public Bzip2ArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, final Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                         final String path, final String slash, final String slash1, final ArchiveConfiguration archiveConfiguration) {
 
        super(binarySignatureIdentifier, containerSignatureDefinitions, path,
-            slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+            slash, slash1, archiveConfiguration);
 
     }
 
@@ -105,7 +104,7 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
                     binarySignatureIdentifier.matchBinarySignatures(bzRequest);
 
             final ResultPrinter resultPrinter = new ResultPrinter(binarySignatureIdentifier,
-                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandAllWebArchives(), super.getExpandWebArchiveTypes());
+                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getArchiveConfiguration());
             resultPrinter.print(bzResults, bzRequest);
         } catch (IOException ioe) {
             System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
@@ -104,7 +104,7 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
                     binarySignatureIdentifier.matchBinarySignatures(bzRequest);
 
             final ResultPrinter resultPrinter = new ResultPrinter(binarySignatureIdentifier,
-                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getArchiveConfiguration());
+                    containerSignatureDefinitions, newPath, slash, slash1, super.getArchiveConfiguration());
             resultPrinter.print(bzResults, bzRequest);
         } catch (IOException ioe) {
             System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
@@ -66,15 +66,15 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public Bzip2ArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, final Boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                         final String path, final String slash, final String slash1, final Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
 
        super(binarySignatureIdentifier, containerSignatureDefinitions, path,
-            slash, slash1, expandWebArchives, expandWebArchiveTypes);
+            slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
 
     }
 
@@ -105,7 +105,7 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
                     binarySignatureIdentifier.matchBinarySignatures(bzRequest);
 
             final ResultPrinter resultPrinter = new ResultPrinter(binarySignatureIdentifier,
-                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandWebArchives(), super.getExpandWebArchiveTypes());
+                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandAllWebArchives(), super.getExpandWebArchiveTypes());
             resultPrinter.print(bzResults, bzRequest);
         } catch (IOException ioe) {
             System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifier.java
@@ -71,14 +71,13 @@ public class FatArchiveContainerIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public FatArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                         final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifier.java
@@ -71,14 +71,14 @@ public class FatArchiveContainerIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public FatArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                         final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifier.java
@@ -66,18 +66,19 @@ public class FatArchiveContainerIdentifier extends ArchiveContentIdentifier {
 
     /**
      * Initialization of instance values must be explicitly called by all children.
-     *
      * @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public FatArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1) {
+                                         final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, false);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
@@ -66,15 +66,14 @@ public class GZipArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          Whether to further expand gzipped web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public GZipArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                         final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                        final String path, final String slash, final String slash1, final Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                        final String path, final String slash, final String slash1, final ArchiveConfiguration archiveConfiguration) {
 
        super(binarySignatureIdentifier, containerSignatureDefinitions, path,
-            slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+            slash, slash1, archiveConfiguration);
 
     }
 
@@ -105,7 +104,7 @@ public class GZipArchiveContentIdentifier extends ArchiveContentIdentifier {
                     binarySignatureIdentifier.matchBinarySignatures(gzRequest);
 
             final ResultPrinter resultPrinter = new ResultPrinter(binarySignatureIdentifier,
-                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandAllWebArchives(), super.getExpandWebArchiveTypes());
+                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getArchiveConfiguration());
             resultPrinter.print(gzResults, gzRequest);
         } catch (IOException ioe) {
             System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
@@ -60,20 +60,21 @@ public class GZipArchiveContentIdentifier extends ArchiveContentIdentifier {
 
 
     /**
-     * 
+     *
      * @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
-     * @param path                          current archive path 
+     * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param webArchives                   Whether to further expand gzipped web archive files
+     * @param expandWebArchives             Whether to further expand gzipped web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public GZipArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
-            final ContainerSignatureDefinitions containerSignatureDefinitions,
-            final String path, final String slash, final String slash1, final Boolean webArchives) {
+                                        final ContainerSignatureDefinitions containerSignatureDefinitions,
+                                        final String path, final String slash, final String slash1, final Boolean expandWebArchives, String[] expandWebArchiveTypes) {
 
        super(binarySignatureIdentifier, containerSignatureDefinitions, path,
-            slash, slash1, webArchives);
+            slash, slash1, expandWebArchives, expandWebArchiveTypes);
 
     }
 
@@ -104,7 +105,7 @@ public class GZipArchiveContentIdentifier extends ArchiveContentIdentifier {
                     binarySignatureIdentifier.matchBinarySignatures(gzRequest);
 
             final ResultPrinter resultPrinter = new ResultPrinter(binarySignatureIdentifier,
-                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandWebArchives());
+                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandWebArchives(), super.getExpandWebArchiveTypes());
             resultPrinter.print(gzResults, gzRequest);
         } catch (IOException ioe) {
             System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
@@ -66,15 +66,15 @@ public class GZipArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             Whether to further expand gzipped web archive files
+     * @param expandAllWebArchives          Whether to further expand gzipped web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public GZipArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                         final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                        final String path, final String slash, final String slash1, final Boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                        final String path, final String slash, final String slash1, final Boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
 
        super(binarySignatureIdentifier, containerSignatureDefinitions, path,
-            slash, slash1, expandWebArchives, expandWebArchiveTypes);
+            slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
 
     }
 
@@ -105,7 +105,7 @@ public class GZipArchiveContentIdentifier extends ArchiveContentIdentifier {
                     binarySignatureIdentifier.matchBinarySignatures(gzRequest);
 
             final ResultPrinter resultPrinter = new ResultPrinter(binarySignatureIdentifier,
-                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandWebArchives(), super.getExpandWebArchiveTypes());
+                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getExpandAllWebArchives(), super.getExpandWebArchiveTypes());
             resultPrinter.print(gzResults, gzRequest);
         } catch (IOException ioe) {
             System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
@@ -104,7 +104,7 @@ public class GZipArchiveContentIdentifier extends ArchiveContentIdentifier {
                     binarySignatureIdentifier.matchBinarySignatures(gzRequest);
 
             final ResultPrinter resultPrinter = new ResultPrinter(binarySignatureIdentifier,
-                    containerSignatureDefinitions, newPath, slash, slash1, true, super.getArchiveConfiguration());
+                    containerSignatureDefinitions, newPath, slash, slash1, super.getArchiveConfiguration());
             resultPrinter.print(gzResults, gzRequest);
         } catch (IOException ioe) {
             System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
@@ -65,14 +65,14 @@ public class IsoArchiveContainerIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public IsoArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                         final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
@@ -60,18 +60,19 @@ public class IsoArchiveContainerIdentifier extends ArchiveContentIdentifier {
 
     /**
      * Initialization of instance values must be explicitly called by all children.
-     *
-     * @param binarySignatureIdentifier     binary signature identifier
+     *  @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public IsoArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1) {
+                                         final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, false);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
@@ -65,14 +65,13 @@ public class IsoArchiveContainerIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public IsoArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                         final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
@@ -68,14 +68,13 @@ public class RarArchiveContainerIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public RarArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                         final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
@@ -68,14 +68,14 @@ public class RarArchiveContainerIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public RarArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                         final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
@@ -63,18 +63,19 @@ public class RarArchiveContainerIdentifier extends ArchiveContentIdentifier {
 
     /**
      * Initialization of instance values must be explicitly called by all children.
-     *
-     * @param binarySignatureIdentifier     binary signature identifier
+     *  @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public RarArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                          final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                         final String path, final String slash, final String slash1) {
+                                         final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, false);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
@@ -66,14 +66,13 @@ public class SevenZipArchiveContainerIdentifier extends ArchiveContentIdentifier
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public SevenZipArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                               final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                              final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                              final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
@@ -66,14 +66,14 @@ public class SevenZipArchiveContainerIdentifier extends ArchiveContentIdentifier
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public SevenZipArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                               final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                              final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                              final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
@@ -61,18 +61,19 @@ public class SevenZipArchiveContainerIdentifier extends ArchiveContentIdentifier
 
     /**
      * Initialization of instance values must be explicitly called by all children.
-     *
-     * @param binarySignatureIdentifier     binary signature identifier
+     *  @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public SevenZipArchiveContainerIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                               final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                              final String path, final String slash, final String slash1) {
+                                              final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
 
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, false);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
     }
 
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
@@ -59,14 +59,13 @@ public class TarArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public TarArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                        final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                       final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                       final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash, expandAllWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash, archiveConfiguration);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
@@ -59,14 +59,14 @@ public class TarArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public TarArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                        final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                       final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                       final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash, expandWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash, expandAllWebArchives, expandWebArchiveTypes);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
@@ -54,18 +54,19 @@ import uk.gov.nationalarchives.droid.core.interfaces.resource.TarEntryIdentifica
 public class TarArchiveContentIdentifier extends ArchiveContentIdentifier {
 
     /**
-     * 
-     * @param binarySignatureIdentifier     binary signature identifier
+     *  @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
-     * @param path                          current archive path 
+     * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public TarArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
-            final ContainerSignatureDefinitions containerSignatureDefinitions,
-            final String path, final String slash, final String slash1) {
+                                       final ContainerSignatureDefinitions containerSignatureDefinitions,
+                                       final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash, false);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash, expandWebArchives, expandWebArchiveTypes);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifier.java
@@ -63,14 +63,14 @@ public class WarcArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public WarcArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                         final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                        final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                        final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifier.java
@@ -63,14 +63,13 @@ public class WarcArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public WarcArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                         final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                        final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                        final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, archiveConfiguration);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifier.java
@@ -58,18 +58,19 @@ import uk.gov.nationalarchives.droid.core.interfaces.resource.RequestMetaData;
 public class WarcArchiveContentIdentifier extends ArchiveContentIdentifier {
 
     /**
-     * 
-     * @param binarySignatureIdentifier     binary signature identifier
+     *  @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
-     * @param path                          current archive path 
+     * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public WarcArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
-            final ContainerSignatureDefinitions containerSignatureDefinitions,
-            final String path, final String slash, final String slash1) {
+                                        final ContainerSignatureDefinitions containerSignatureDefinitions,
+                                        final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
     
-        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, false);
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
@@ -55,19 +55,20 @@ public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
 
 
     /**
-     * 
-     * @param binarySignatureIdentifier     binary signature identifier
+     *  @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
-     * @param path                          current archive path 
+     * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
+     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public ZipArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
-            final ContainerSignatureDefinitions containerSignatureDefinitions,
-            final String path, final String slash, final String slash1) {
+                                       final ContainerSignatureDefinitions containerSignatureDefinitions,
+                                       final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
     
             super(binarySignatureIdentifier, containerSignatureDefinitions,
-        path, slash, slash1, false);
+        path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
@@ -60,15 +60,14 @@ public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandAllWebArchives          optionally expand all web archive files
-     * @param expandWebArchiveTypes         list of web archive types to examine
+     * @param archiveConfiguration          configuration to expand archives and web archives
      */
     public ZipArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                        final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                       final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
+                                       final String path, final String slash, final String slash1, ArchiveConfiguration archiveConfiguration) {
     
             super(binarySignatureIdentifier, containerSignatureDefinitions,
-        path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
+        path, slash, slash1, archiveConfiguration);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
@@ -60,15 +60,15 @@ public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
-     * @param expandWebArchives             optionally expand all web archive files
+     * @param expandAllWebArchives          optionally expand all web archive files
      * @param expandWebArchiveTypes         list of web archive types to examine
      */
     public ZipArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
                                        final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                       final String path, final String slash, final String slash1, boolean expandWebArchives, String[] expandWebArchiveTypes) {
+                                       final String path, final String slash, final String slash1, boolean expandAllWebArchives, String[] expandWebArchiveTypes) {
     
             super(binarySignatureIdentifier, containerSignatureDefinitions,
-        path, slash, slash1, expandWebArchives, expandWebArchiveTypes);
+        path, slash, slash1, expandAllWebArchives, expandWebArchiveTypes);
     }
     
     /**

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
@@ -96,6 +96,9 @@ public final class I18N {
     /** Help for archives. */
     public static final String ARCHIVES_HELP = "archives.help";
 
+    /** Help for web archive types. */
+    public static final String ARCHIVE_TYPES_HELP = "archive_types.help";
+
     /** Help for web archives. */
     public static final String WEB_ARCHIVES_HELP = "web_archives.help";
 

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
@@ -96,8 +96,11 @@ public final class I18N {
     /** Help for archives. */
     public static final String ARCHIVES_HELP = "archives.help";
 
-    /** Help for archives. */
+    /** Help for web archives. */
     public static final String WEB_ARCHIVES_HELP = "web_archives.help";
+
+    /** Help for web archive types. */
+    public static final String WEB_ARCHIVE_TYPES_HELP = "web_archive_types.help";
 
     /** Recurse subdirectories. */
     public static final String RECURSE_HELP = "recurse.help";

--- a/droid-command-line/src/main/resources/archive-puids.properties
+++ b/droid-command-line/src/main/resources/archive-puids.properties
@@ -32,7 +32,7 @@
 
 # Maps archive puids to the archive format.
 
-archive.zip=x-fmt/263, x-fmt/412
+archive.zip=x-fmt/263
 archive.tar=x-fmt/265
 archive.gz=x-fmt/266
 archive.arc=x-fmt/219, fmt/410

--- a/droid-command-line/src/main/resources/options.properties
+++ b/droid-command-line/src/main/resources/options.properties
@@ -59,7 +59,7 @@ recurse.help=[optional] Recurse into all subfolders of any folder specified usin
 Files in all sub-folders (and their sub-folders, and so on) will be processed as well. \
 If this option is omitted and a folder is specified, only the files directly under the folder will be processed. \For example: \n droid -R -a "C:\\Files\\Another Folder" -p "C:\\Results\\result3.droid"
 archives.help=[optional] Open all archive (ZIP, TAR, GZIP, RAR, 7ZIP, BZIP2 and ISO) files and identify all their contents.
-archive_types.help=[optional] List of web archive types to analyse among "ZIP", "TAR", "GZIP", "RAR", "7ZIP", "ZIP", "BZIP2" and "ISO", separated by space. Ignored if -A is used. 
+archive_types.help=[optional] List of archive types to analyse among "ZIP", "TAR", "GZIP", "RAR", "7ZIP", "BZIP2" and "ISO", separated by space. Ignored if -A is used. 
 web_archives.help=[optional] Open all web archive (ARC, WARC) files and identify their contents
 web_archive_types.help=[optional] List of web archive types to analyse among "ARC" "WARC", separated by space. Ignored if -W is used. 
 quiet.help=[optional] When run in PROFILE mode DROID will limit its console output to errors only.  When run in NO PROFILE mode DROID will limit its output to CSV data only.

--- a/droid-command-line/src/main/resources/options.properties
+++ b/droid-command-line/src/main/resources/options.properties
@@ -58,7 +58,8 @@ extension_list.help=[optional] Only identify files with the given extensions \nF
 recurse.help=[optional] Recurse into all subfolders of any folder specified using the -a or -Nr options. \
 Files in all sub-folders (and their sub-folders, and so on) will be processed as well. \
 If this option is omitted and a folder is specified, only the files directly under the folder will be processed. \For example: \n droid -R -a "C:\\Files\\Another Folder" -p "C:\\Results\\result3.droid"
-archives.help=[optional] Open archive (zip, tar, gzip, rar, 7zip, bzip2, iso) files and identify all their contents.
+archives.help=[optional] Open all archive (ZIP, TAR, GZIP, RAR, 7ZIP, BZIP2 and ISO) files and identify all their contents.
+archive_types.help=[optional] List of web archive types to analyse among "ZIP", "TAR", "GZIP", "RAR", "7ZIP", "ZIP", "BZIP2" and "ISO", separated by space. Ignored if -A is used. 
 web_archives.help=[optional] Open all web archive (ARC, WARC) files and identify their contents
 web_archive_types.help=[optional] List of web archive types to analyse among "ARC" "WARC", separated by space. Ignored if -W is used. 
 quiet.help=[optional] When run in PROFILE mode DROID will limit its console output to errors only.  When run in NO PROFILE mode DROID will limit its output to CSV data only.

--- a/droid-command-line/src/main/resources/options.properties
+++ b/droid-command-line/src/main/resources/options.properties
@@ -59,7 +59,8 @@ recurse.help=[optional] Recurse into all subfolders of any folder specified usin
 Files in all sub-folders (and their sub-folders, and so on) will be processed as well. \
 If this option is omitted and a folder is specified, only the files directly under the folder will be processed. \For example: \n droid -R -a "C:\\Files\\Another Folder" -p "C:\\Results\\result3.droid"
 archives.help=[optional] Open archive (zip, tar, gzip, rar, 7zip, bzip2, iso) files and identify all their contents.
-web_archives.help=[optional] Open ARC or WARC files and identify their contents
+web_archives.help=[optional] Open all web archive (ARC, WARC) files and identify their contents
+web_archive_types.help=[optional] List of web archive types to analyse among "ARC" "WARC", separated by space. Ignored if -W is used. 
 quiet.help=[optional] When run in PROFILE mode DROID will limit its console output to errors only.  When run in NO PROFILE mode DROID will limit its output to CSV data only.
 report.list.help=List the available reports and output formats.
 report.type.help=Set the output file format of a report.

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
@@ -71,9 +71,6 @@ public class ArcArchiveContentIdentifierTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
-
     @Before
     public void setUp() throws CommandExecutionException {
         binarySignatureIdentifier = new BinarySignatureIdentifier();
@@ -93,7 +90,7 @@ public class ArcArchiveContentIdentifierTest {
         }
         arcArchiveContentIdentifier =
                 new ArcArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
@@ -71,6 +71,9 @@ public class ArcArchiveContentIdentifierTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
+
     @Before
     public void setUp() throws CommandExecutionException {
         binarySignatureIdentifier = new BinarySignatureIdentifier();
@@ -90,7 +93,7 @@ public class ArcArchiveContentIdentifierTest {
         }
         arcArchiveContentIdentifier =
                 new ArcArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/");
+                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
@@ -93,7 +93,7 @@ public class ArcArchiveContentIdentifierTest {
         }
         arcArchiveContentIdentifier =
                 new ArcArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
@@ -90,7 +90,7 @@ public class ArcArchiveContentIdentifierTest {
         }
         arcArchiveContentIdentifier =
                 new ArcArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null, true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
@@ -89,7 +89,7 @@ public class BZip2ArchiveContentIdentifierTest {
         }
         bzip2ArchiveContentIdentifier =
                 new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
@@ -67,8 +67,6 @@ public class BZip2ArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String gZipFile =
             "src/test/resources/testfiles/testXmlFile.xml.bz2";
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -89,7 +87,7 @@ public class BZip2ArchiveContentIdentifierTest {
         }
         bzip2ArchiveContentIdentifier =
                 new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
@@ -67,7 +67,9 @@ public class BZip2ArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String gZipFile =
             "src/test/resources/testfiles/testXmlFile.xml.bz2";
-    
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
+
     @Before
     public void setUp() throws CommandExecutionException {
         binarySignatureIdentifier = new BinarySignatureIdentifier();
@@ -87,7 +89,7 @@ public class BZip2ArchiveContentIdentifierTest {
         }
         bzip2ArchiveContentIdentifier =
                 new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", false);
+                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
@@ -87,7 +87,7 @@ public class BZip2ArchiveContentIdentifierTest {
         }
         bzip2ArchiveContentIdentifier =
                 new Bzip2ArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null, true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
@@ -50,6 +50,8 @@ public class FatArchiveContainerIdentifierTest {
 
     private ArchiveContainerTestHelper testHelper = new ArchiveContainerTestHelper();
     private Path filePath = Paths.get("src/test/resources/testfiles/fat12.img");
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Test
     public void identifyFatFile() throws CommandExecutionException, IOException {
@@ -64,7 +66,7 @@ public class FatArchiveContainerIdentifierTest {
 
         FatArchiveContainerIdentifier fatArchiveContainerIdentifier =
                 new FatArchiveContainerIdentifier(testHelper.getBinarySignatureIdentifier(),
-                        testHelper.getContainerSignatureDefinitions(), "", "/", "/");
+                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", true, webArchiveTypes);
 
         fatArchiveContainerIdentifier.identify(filePath.toUri(), request);
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
@@ -64,7 +64,7 @@ public class FatArchiveContainerIdentifierTest {
 
         FatArchiveContainerIdentifier fatArchiveContainerIdentifier =
                 new FatArchiveContainerIdentifier(testHelper.getBinarySignatureIdentifier(),
-                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, null));
+                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, null, true, null));
 
         fatArchiveContainerIdentifier.identify(filePath.toUri(), request);
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
@@ -50,8 +50,6 @@ public class FatArchiveContainerIdentifierTest {
 
     private ArchiveContainerTestHelper testHelper = new ArchiveContainerTestHelper();
     private Path filePath = Paths.get("src/test/resources/testfiles/fat12.img");
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Test
     public void identifyFatFile() throws CommandExecutionException, IOException {
@@ -66,7 +64,7 @@ public class FatArchiveContainerIdentifierTest {
 
         FatArchiveContainerIdentifier fatArchiveContainerIdentifier =
                 new FatArchiveContainerIdentifier(testHelper.getBinarySignatureIdentifier(),
-                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, null));
 
         fatArchiveContainerIdentifier.identify(filePath.toUri(), request);
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
@@ -66,7 +66,7 @@ public class FatArchiveContainerIdentifierTest {
 
         FatArchiveContainerIdentifier fatArchiveContainerIdentifier =
                 new FatArchiveContainerIdentifier(testHelper.getBinarySignatureIdentifier(),
-                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", true, webArchiveTypes);
+                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
 
         fatArchiveContainerIdentifier.identify(filePath.toUri(), request);
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
@@ -66,8 +66,6 @@ public class GZipArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String gZipFile =
             "src/test/resources/testfiles/test.gz";
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -88,7 +86,7 @@ public class GZipArchiveContentIdentifierTest {
         }
         gZipArchiveContentIdentifier =
                 new GZipArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
@@ -86,7 +86,7 @@ public class GZipArchiveContentIdentifierTest {
         }
         gZipArchiveContentIdentifier =
                 new GZipArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null, true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
@@ -88,7 +88,7 @@ public class GZipArchiveContentIdentifierTest {
         }
         gZipArchiveContentIdentifier =
                 new GZipArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
@@ -66,7 +66,9 @@ public class GZipArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String gZipFile =
             "src/test/resources/testfiles/test.gz";
-    
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
+
     @Before
     public void setUp() throws CommandExecutionException {
         binarySignatureIdentifier = new BinarySignatureIdentifier();
@@ -86,7 +88,7 @@ public class GZipArchiveContentIdentifierTest {
         }
         gZipArchiveContentIdentifier =
                 new GZipArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", false);
+                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
@@ -65,7 +65,7 @@ public class IsoArchiveContainerIdentifierTest {
 
         IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
                 new IsoArchiveContainerIdentifier(testHelper.getBinarySignatureIdentifier(),
-                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, null));
+                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, null, true, null));
 
         isoArchiveContainerIdentifier.identify(filePath.toUri(), request);
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
@@ -51,8 +51,6 @@ public class IsoArchiveContainerIdentifierTest {
 
     private ArchiveContainerTestHelper testHelper = new ArchiveContainerTestHelper();
     private Path filePath = Paths.get("src/test/resources/testfiles/testiso.iso");
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Test
     public void identifyIsoFile()throws CommandExecutionException, IOException {
@@ -67,7 +65,7 @@ public class IsoArchiveContainerIdentifierTest {
 
         IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
                 new IsoArchiveContainerIdentifier(testHelper.getBinarySignatureIdentifier(),
-                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, null));
 
         isoArchiveContainerIdentifier.identify(filePath.toUri(), request);
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
@@ -51,6 +51,8 @@ public class IsoArchiveContainerIdentifierTest {
 
     private ArchiveContainerTestHelper testHelper = new ArchiveContainerTestHelper();
     private Path filePath = Paths.get("src/test/resources/testfiles/testiso.iso");
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Test
     public void identifyIsoFile()throws CommandExecutionException, IOException {
@@ -65,7 +67,7 @@ public class IsoArchiveContainerIdentifierTest {
 
         IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
                 new IsoArchiveContainerIdentifier(testHelper.getBinarySignatureIdentifier(),
-                        testHelper.getContainerSignatureDefinitions(), "", "/", "/");
+                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", true, webArchiveTypes);
 
         isoArchiveContainerIdentifier.identify(filePath.toUri(), request);
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
@@ -67,7 +67,7 @@ public class IsoArchiveContainerIdentifierTest {
 
         IsoArchiveContainerIdentifier isoArchiveContainerIdentifier =
                 new IsoArchiveContainerIdentifier(testHelper.getBinarySignatureIdentifier(),
-                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", true, webArchiveTypes);
+                        testHelper.getContainerSignatureDefinitions(), "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
 
         isoArchiveContainerIdentifier.identify(filePath.toUri(), request);
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
@@ -86,7 +86,7 @@ public class RarArchiveContainerIdentifierTest {
         }
         rarArchiveContainerIdentifier =
                 new RarArchiveContainerIdentifier(binarySignatureIdentifier,
-                        containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
+                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
     }
 
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
@@ -64,8 +64,6 @@ public class RarArchiveContainerIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String rarFile =
             "src/test/resources/testfiles/sample.rar";
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -86,7 +84,7 @@ public class RarArchiveContainerIdentifierTest {
         }
         rarArchiveContainerIdentifier =
                 new RarArchiveContainerIdentifier(binarySignatureIdentifier,
-                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
     }
 
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
@@ -84,7 +84,7 @@ public class RarArchiveContainerIdentifierTest {
         }
         rarArchiveContainerIdentifier =
                 new RarArchiveContainerIdentifier(binarySignatureIdentifier,
-                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
+                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null, true, null));
     }
 
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
@@ -64,6 +64,8 @@ public class RarArchiveContainerIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String rarFile =
             "src/test/resources/testfiles/sample.rar";
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -84,7 +86,7 @@ public class RarArchiveContainerIdentifierTest {
         }
         rarArchiveContainerIdentifier =
                 new RarArchiveContainerIdentifier(binarySignatureIdentifier,
-                        containerSignatureDefinitions, "", "/", "/");
+                        containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
     }
 
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
@@ -64,8 +64,6 @@ public class SevenZipArchiveContainerIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String sevenZipFile =
             "src/test/resources/testfiles/saved.7z";
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -86,7 +84,7 @@ public class SevenZipArchiveContainerIdentifierTest {
         }
         sevenZipArchiveContainerIdentifier =
                 new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
-                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
     }
 
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
@@ -64,6 +64,8 @@ public class SevenZipArchiveContainerIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String sevenZipFile =
             "src/test/resources/testfiles/saved.7z";
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -84,7 +86,7 @@ public class SevenZipArchiveContainerIdentifierTest {
         }
         sevenZipArchiveContainerIdentifier =
                 new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
-                        containerSignatureDefinitions, "", "/", "/");
+                        containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
     }
 
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
@@ -86,7 +86,7 @@ public class SevenZipArchiveContainerIdentifierTest {
         }
         sevenZipArchiveContainerIdentifier =
                 new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
-                        containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
+                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
     }
 
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
@@ -84,7 +84,7 @@ public class SevenZipArchiveContainerIdentifierTest {
         }
         sevenZipArchiveContainerIdentifier =
                 new SevenZipArchiveContainerIdentifier(binarySignatureIdentifier,
-                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
+                        containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null, true, null));
     }
 
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
@@ -86,7 +86,7 @@ public class TarArchiveContentIdentifierTest {
         }
         tarArchiveContentIdentifier =
                 new TarArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null, true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
@@ -88,7 +88,7 @@ public class TarArchiveContentIdentifierTest {
         }
         tarArchiveContentIdentifier =
                 new TarArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
@@ -66,8 +66,6 @@ public class TarArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String tarFile =
             "src/test/resources/testfiles/test.tar";
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -88,7 +86,7 @@ public class TarArchiveContentIdentifierTest {
         }
         tarArchiveContentIdentifier =
                 new TarArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
@@ -66,7 +66,9 @@ public class TarArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String tarFile =
             "src/test/resources/testfiles/test.tar";
-    
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
+
     @Before
     public void setUp() throws CommandExecutionException {
         binarySignatureIdentifier = new BinarySignatureIdentifier();
@@ -86,7 +88,7 @@ public class TarArchiveContentIdentifierTest {
         }
         tarArchiveContentIdentifier =
                 new TarArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/");
+                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
@@ -87,7 +87,7 @@ public class WarcArchiveContentIdentifierTest {
         }
         warcArchiveContentIdentifier =
                 new WarcArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
@@ -65,8 +65,6 @@ public class WarcArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String warcFile =
             "src/test/resources/testfiles/expanded.warc";
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -87,7 +85,7 @@ public class WarcArchiveContentIdentifierTest {
         }
         warcArchiveContentIdentifier =
                 new WarcArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
@@ -85,7 +85,7 @@ public class WarcArchiveContentIdentifierTest {
         }
         warcArchiveContentIdentifier =
                 new WarcArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null, true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
@@ -65,7 +65,9 @@ public class WarcArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String warcFile =
             "src/test/resources/testfiles/expanded.warc";
-    
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
+
     @Before
     public void setUp() throws CommandExecutionException {
         binarySignatureIdentifier = new BinarySignatureIdentifier();
@@ -85,7 +87,7 @@ public class WarcArchiveContentIdentifierTest {
         }
         warcArchiveContentIdentifier =
                 new WarcArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/");
+                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
@@ -86,7 +86,7 @@ public class ZipArchiveContentIdentifierTest {
         }
         zipArchiveContentIdentifier =
                 new ZipArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null, true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
@@ -66,8 +66,6 @@ public class ZipArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String zipFile =
             "src/test/resources/testfiles/test.zip";
-    private String[] webArchiveTypes = new String[]{"arc", "warc"};
-//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
 
     @Before
     public void setUp() throws CommandExecutionException {
@@ -88,7 +86,7 @@ public class ZipArchiveContentIdentifierTest {
         }
         zipArchiveContentIdentifier =
                 new ZipArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, null));
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
@@ -66,7 +66,9 @@ public class ZipArchiveContentIdentifierTest {
             Paths.get("src/test/resources/signatures/container-signature-20170330.xml");
     private String zipFile =
             "src/test/resources/testfiles/test.zip";
-    
+    private String[] webArchiveTypes = new String[]{"arc", "warc"};
+//    private String[] archiveTypes = new String[]{"zip", "tar", "gzip", "rar", "7", "zip", "bzip2", "iso"};
+
     @Before
     public void setUp() throws CommandExecutionException {
         binarySignatureIdentifier = new BinarySignatureIdentifier();
@@ -86,7 +88,7 @@ public class ZipArchiveContentIdentifierTest {
         }
         zipArchiveContentIdentifier =
                 new ZipArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/");
+                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
     }
     
     @After

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
@@ -88,7 +88,7 @@ public class ZipArchiveContentIdentifierTest {
         }
         zipArchiveContentIdentifier =
                 new ZipArchiveContentIdentifier(binarySignatureIdentifier,
-                    containerSignatureDefinitions, "", "/", "/", true, webArchiveTypes);
+                    containerSignatureDefinitions, "", "/", "/", new ArchiveConfiguration(true, webArchiveTypes));
     }
     
     @After

--- a/droid-core-interfaces/src/main/resources/archive-puids.properties
+++ b/droid-core-interfaces/src/main/resources/archive-puids.properties
@@ -32,7 +32,7 @@
 
 # Maps archive puids to the archive format.
 
-archive.zip=x-fmt/263, x-fmt/412
+archive.zip=x-fmt/263
 archive.tar=x-fmt/265
 archive.gz=x-fmt/266
 archive.arc=x-fmt/219, fmt/410

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolverImplTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolverImplTest.java
@@ -63,7 +63,6 @@ public class ArchiveFormatResolverImplTest {
     
     @Test
     public void testForPuid() {
-        assertEquals("ZIP", formatResolver.forPuid("x-fmt/412"));
         assertEquals("ZIP", formatResolver.forPuid("x-fmt/263"));
         assertEquals("TAR", formatResolver.forPuid("x-fmt/265"));
         assertEquals("GZ", formatResolver.forPuid("x-fmt/266"));

--- a/droid-help/src/main/resources/Web pages/Command line control.html
+++ b/droid-help/src/main/resources/Web pages/Command line control.html
@@ -532,10 +532,16 @@
        [optional] Open archive (zip, tar, gzip) files and identify all their contents.
     </p>
     <h3>
-        -W,&nbsp;--open-webarchives
+      -W,&nbsp;--open-all-webarchives
     </h3>
     <p>
-        [optional] Open web archive (arc, warc) files and identify their contents. Usually used in conjunction with -A.
+      [optional] Open all web archive (arc, warc) files and identify their contents. Usually used in conjunction with -A.
+    </p>
+    <h3>
+      -Wt,&nbsp;--open-webarchive-types
+    </h3>
+    <p>
+      [optional] List of web archive types to analyse among "ARC" "WARC", separated by space. Ignored if -W is used. Usually used in conjunction with -A.
     </p>
     <p>
        &nbsp;

--- a/droid-help/src/main/resources/Web pages/Command line control.html
+++ b/droid-help/src/main/resources/Web pages/Command line control.html
@@ -526,22 +526,28 @@
       </table>
     </p>
     <h3>
-       -A,&nbsp;--open-archives
+       -A,&nbsp;--open-all-archives
     </h3>
     <p>
-       [optional] Open archive (zip, tar, gzip) files and identify all their contents.
+       [optional] Open all archive (zip, tar, gzip, rar, 7zip, bzip2, iso) files and identify all their contents. Usually used in conjunction with -W or -Wt.
+    </p>
+    <h3>
+      -At,&nbsp;--open-archive-types
+    </h3>
+    <p>
+      [optional] List of archive types to analyse among "ZIP", "TAR", "GZIP", "RAR", "7ZIP", "BZIP2" and "ISO" separated by space. Ignored if -A is used. Usually used in conjunction with -W or -Wt.
     </p>
     <h3>
       -W,&nbsp;--open-all-webarchives
     </h3>
     <p>
-      [optional] Open all web archive (arc, warc) files and identify their contents. Usually used in conjunction with -A.
+      [optional] Open all web archive (arc, warc) files and identify their contents. Usually used in conjunction with -A or -At.
     </p>
     <h3>
       -Wt,&nbsp;--open-webarchive-types
     </h3>
     <p>
-      [optional] List of web archive types to analyse among "ARC" "WARC", separated by space. Ignored if -W is used. Usually used in conjunction with -A.
+      [optional] List of web archive types to analyse among "ARC" "WARC", separated by space. Ignored if -W is used. Usually used in conjunction with -A or -At.
     </p>
     <p>
        &nbsp;

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionGateway.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionGateway.java
@@ -356,15 +356,6 @@ public class SubmissionGateway implements AsynchDroid {
     //CHECKSTYLE:ON
 
 
-    /**
-     *
-     * @param format
-     * @return true if a Web Archive format
-     */
-    private Boolean isWebArchiveFormat(String format) {
-        return "ARC".equals(format) || "WARC".equals(format);
-    }
-
     private String getContainerFormat(IdentificationResultCollection results) {
         final List<IdentificationResult> theResults = results.getResults();
         final int numResults = theResults.size(); // use an indexed loop to reduce garbage, don't allocate an iterator.

--- a/droid-results/src/main/resources/archive-puids.properties
+++ b/droid-results/src/main/resources/archive-puids.properties
@@ -32,7 +32,7 @@
 
 # Maps archive puids to the archive format.
 
-archive.zip=x-fmt/263, x-fmt/412
+archive.zip=x-fmt/263
 archive.tar=x-fmt/265
 archive.gz=x-fmt/266
 archive.arc=x-fmt/219, fmt/410

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/SubmissionGatewayTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/SubmissionGatewayTest.java
@@ -104,7 +104,6 @@ public class SubmissionGatewayTest {
 
         ArchiveFormatResolver archiveFormatResolver = mock(ArchiveFormatResolver.class);
         ArchiveHandlerFactory archiveHandlerFactory = mock(ArchiveHandlerFactory.class);
-        when(archiveFormatResolver.forPuid("x-fmt/412")).thenReturn("ZIP");
 
         TrueZipArchiveHandler zipHandler = new TrueZipArchiveHandler();
         zipHandler.setDroidCore(submissionGateway);


### PR DESCRIPTION
# Context
related to https://github.com/digital-preservation/droid/issues/184 request
- UI work already merged and in PR https://github.com/digital-preservation/droid/pull/334
- This PR enables selection of archives and web archives to expand in the Command Line Interface

# Changes
To make archive management consistent across UI and CLI, and across all archive / web archive types, the following changes were also made:
- manage RAR files
- for all archives, if they contain archive children which are expandable according to configuration, they will be expanded.


# Acceptance tests

- create folder and unzip there the provided archive of samples of archives ISO/RAR/7Z/TAR/BZIP2/GZIP/ZIP and web archives ARC/WARC
- run the following test cases with the command line interface (DroidCommandLine class on IDE or from packaged binary with droid.sh script) and given program arguments
  - COMMON to all test cases: use program arguments (update the paths to fit your environment)
No profile run, with signature and container sig files.
```
-Nr /home/jeremie/Documents/drive_TNA/droid/samples/archives/ -Ns /home/jeremie/.droid6/signature_files/DROID_SignatureFile_V91.xml -Nc /home/jeremie/.droid6/container_sigs/container-signature-20170330.xml
```
-  - Test: test lack of expansion: no archive should be expanded
run with program arguments above only
  - Test: test expansion of all archives and web archives
add following program arguments to those above:
```
-A -W
```
-  - Test: test expansion of all archives: only archives should be expanded
all archives contained in archives should be expanded as well
```
-A
```
-  - Test: test expansion of all archives: only archives should be expanded (using type parameter At)
```
-At ZIP TAR GZIP RAR 7ZIP BZIP2 ISO
```
  - Test: test expansion of all web archives: only web archives should be expanded
```
-W
```
-  - Test: test expansion of all web archives: only web archives should be expanded (using type parameter Wt)
```
-Wt ARC WARC
```
-  - Test: test expansion of every specific archive type: use -At with each supported type, one at a time
```
-At ZIP
```
,
```
-At TAR
```
, etc
-  - Test: test expansion of every specific web archive type: use -Wt with each supported type, one at a time
```
-Wt ARC
```
,
```
-Wt WARC
```

# Tasks
- [x] find sample files
- [x] manage web archives
- [x] manage  archives
- [x] manage rar
- [x] make expansion of sub archives consistent across all archives
- [x] fix Jar management: containers
- [x] investigate expansion of 7z iso and rar archives
- [ ] fix logging