### PR TITLE
Corrected email-id in the copyright header across all files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/droid-binary/LICENSE
+++ b/droid-binary/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/droid-binary/assembly-windows-with-jre.xml
+++ b/droid-binary/assembly-windows-with-jre.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-binary/assembly.xml
+++ b/droid-binary/assembly.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-binary/bin/Running DROID.txt
+++ b/droid-binary/bin/Running DROID.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-binary/bin/droid.bat
+++ b/droid-binary/bin/droid.bat
@@ -1,5 +1,5 @@
 @REM
-@REM Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+@REM Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 @REM All rights reserved.
 @REM
 @REM Redistribution and use in source and binary forms, with or without

--- a/droid-binary/bin/droid.sh
+++ b/droid-binary/bin/droid.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-binary/conf/log4j2.properties
+++ b/droid-binary/conf/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-build-tools/src/main/resources/checkstyle-main.xml
+++ b/droid-build-tools/src/main/resources/checkstyle-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/checkstyle/suppressions.xml
+++ b/droid-command-line/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/nbactions.xml
+++ b/droid-command-line/nbactions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/DroidCommandLine.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/DroidCommandLine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/FilterFieldCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/FilterFieldCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/ResultPrinter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CheckSignatureUpdateCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CheckSignatureUpdateCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandExecutionException.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandExecutionException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactory.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineErrorCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineErrorCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineException.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineSyntaxException.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineSyntaxException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ConfigureDefaultSignatureFileVersionCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ConfigureDefaultSignatureFileVersionCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/DisplayDefaultSignatureFileVersionCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/DisplayDefaultSignatureFileVersionCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/DownloadSignatureUpdateCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/DownloadSignatureUpdateCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/DroidCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/DroidCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ExportCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ExportCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/HelpCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/HelpCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListAllSignatureFilesCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListAllSignatureFilesCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/LocationResolver.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/LocationResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ProfileRunCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ReportCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ReportCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/VersionCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/VersionCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/AbstractContainerContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/AbstractContainerContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/ContainerContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/ContainerContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/ContainerContentIdentifierFactory.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/ContainerContentIdentifierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/Ole2ContainerContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/Ole2ContainerContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/ZipContainerContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/container/ZipContainerContentIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/context/GlobalContext.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/context/GlobalContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/context/SpringUiContext.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/context/SpringUiContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/AbstractFilterCriterion.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/AbstractFilterCriterion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/CommandLineFilter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/CommandLineFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/CriterionFactory.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/CriterionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/DqlCriterionFactory.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/DqlCriterionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/DqlCriterionMapper.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/DqlCriterionMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/DqlFilterParser.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/DqlFilterParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/DqlParseException.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/DqlParseException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/SimpleDqlFilterParser.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/SimpleDqlFilterParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/SimpleFilter.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/SimpleFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/resources/META-INF/ui-spring.xml
+++ b/droid-command-line/src/main/resources/META-INF/ui-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/resources/archive-puids.properties
+++ b/droid-command-line/src/main/resources/archive-puids.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/resources/log4j2.properties
+++ b/droid-command-line/src/main/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/main/resources/options.properties
+++ b/droid-command-line/src/main/resources/options.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/ReportCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/ReportCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/TestContexCleanup.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/TestContexCleanup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/TestUtil.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/TestUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CheckSignatureUpdateCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CheckSignatureUpdateCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandLineParamTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandLineParamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ConfigureDefaultSignatureFileVersionCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ConfigureDefaultSignatureFileVersionCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/DisplayDefaultSignatureFileVersionTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/DisplayDefaultSignatureFileVersionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/DownloadSignatureUpdateCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/DownloadSignatureUpdateCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ExportCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ExportCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/FilterFieldCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/FilterFieldCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ListAllSignatureFilesCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ListAllSignatureFilesCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/NonsenseCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/NonsenseCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ProfileRunCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ProfileRunCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArcArchiveContentIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContainerTestHelper.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContainerTestHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/BZip2ArchiveContentIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/FatArchiveContainerIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/GZipArchiveContentIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/TarArchiveContentIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/WarcArchiveContentIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/archive/ZipArchiveContentIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/container/Ole2ContainerContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/container/Ole2ContainerContentIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/container/ZipContainerContentIdentifierTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/container/ZipContainerContentIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/filter/DqlCriterionMapperTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/filter/DqlCriterionMapperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/filter/SimpleDqlParserFilterGrammarTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/filter/SimpleDqlParserFilterGrammarTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-command-line/src/test/resources/log4j2.properties
+++ b/droid-command-line/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-container/checkstyle/suppressions.xml
+++ b/droid-container/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/AbstractContainerIdentifier.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/AbstractContainerIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/AbstractIdentifierEngine.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/AbstractIdentifierEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/BinarySignatureMatcher.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/BinarySignatureMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/BinarySignatureXMLParser.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/BinarySignatureXMLParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerFile.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerFileIdentificationRequest.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerFileIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerFileIdentificationRequestFactory.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerFileIdentificationRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerIdentifierInit.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerIdentifierInit.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignature.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureDefinitions.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureDefinitions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureFileReader.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureFileReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatch.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchCollection.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureSaxParser.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureSaxParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/FileFormatMapping.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/FileFormatMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/IdentifierEngine.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/IdentifierEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/TextSignatureMatcher.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/TextSignatureMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/TriggerPuid.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/TriggerPuid.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/XmlFragment.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/XmlFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/httpservice/ContainerSignatureHttpService.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/httpservice/ContainerSignatureHttpService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ole2/Ole2Identifier.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ole2/Ole2Identifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ole2/Ole2IdentifierEngine.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ole2/Ole2IdentifierEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/zip/ZipIdentifier.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/zip/ZipIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/zip/ZipIdentifierEngine.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/zip/ZipIdentifierEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureSaxParserTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureSaxParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/OdfSignatureParserTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/OdfSignatureParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/httpservice/ContainerSignatureHttpServiceTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/httpservice/ContainerSignatureHttpServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/legacy/Droid4BinarySignatureMatcherTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/legacy/Droid4BinarySignatureMatcherTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/odf/OdfIdentifierTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/odf/OdfIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ole2/Ole2RootFileTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ole2/Ole2RootFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ooxml/OoXmlIdentifierTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ooxml/OoXmlIdentifierTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-container/src/test/resources/log4j2.properties
+++ b/droid-container/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/checkstyle/suppressions.xml
+++ b/droid-core-interfaces/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/AsynchDroid.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/AsynchDroid.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/BlockingThreadPoolExecutorFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/BlockingThreadPoolExecutorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/ConfidenceLevel.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/ConfidenceLevel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/DroidCore.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/DroidCore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/EnumerationAdapter.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/EnumerationAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationErrorType.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationErrorType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationException.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationMethod.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationMethod.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationResult.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationResultCollection.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationResultCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationResultImpl.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationResultImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/NodeStatus.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/NodeStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/RequestIdentifier.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/RequestIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/ResourceId.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/ResourceId.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/ResourceType.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/ResourceType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/ResultHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/ResultHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/SubmissionStatus.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/SubmissionStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/TextEncoding.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/TextEncoding.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/AbstractArchiveRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/AbstractArchiveRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArcArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArcArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFileUtils.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFileUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFileWalker.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFileWalker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolver.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolverImpl.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolverImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveHandlerFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveHandlerFactoryImpl.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveHandlerFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveInputStreamIterator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveInputStreamIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveIterationException.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveIterationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/BZipArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/BZipArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/BZipRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/BZipRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ContainerIdentifier.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ContainerIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ContainerIdentifierFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ContainerIdentifierFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ContainerIdentifierFactoryImpl.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ContainerIdentifierFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatEntryRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatEntryRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatReader.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/GZipArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/GZipArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/GZipRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/GZipRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ISOEntryRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ISOEntryRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ISOImageArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ISOImageArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/IdentificationRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/IdentificationRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarEntryRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarEntryRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarReader.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipIteratorAdapter.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipIteratorAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipReader.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TarArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TarArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TarEntryRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TarEntryRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TrueZipArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TrueZipArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TrueZipReader.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TrueZipReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/WarcArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/WarcArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/WebArchiveEntryRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/WebArchiveEntryRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/WebArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/WebArchiveHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ZipEntryRequestFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ZipEntryRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalConfig.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalProperty.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/DroidGlobalProperty.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/RuntimeConfig.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/config/RuntimeConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/PauseAfter.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/PauseAfter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/PauseAspect.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/PauseAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/PauseBefore.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/PauseBefore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/ThreadWaitingHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/control/ThreadWaitingHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/AbstractFilterCriterion.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/AbstractFilterCriterion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/CriterionFieldEnum.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/CriterionFieldEnum.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/CriterionOperator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/CriterionOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/Filter.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/Filter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/FilterCriterion.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/FilterCriterion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/FilterValue.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/FilterValue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/RestrictionFactory.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/RestrictionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Conjunction.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Conjunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Criterion.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Criterion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Disjunction.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Disjunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Junction.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Junction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/QueryBuilder.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/QueryBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Restrictions.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/Restrictions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/HashGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/MD5HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/MD5HashGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA256HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA256HashGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/BZipIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/BZipIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FatFileIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FatFileIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ISOImageIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ISOImageIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/RarIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/RarIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/RequestMetaData.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/RequestMetaData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ResourceId.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ResourceId.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ResourceUtils.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ResourceUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/SevenZipEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/SevenZipEntryIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/TarEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/TarEntryIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/WebArchiveEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/WebArchiveEntryIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ZipEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ZipEntryIdentificationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/ErrorCode.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/ErrorCode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/ProxySettings.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/ProxySettings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/ProxySubscriber.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/ProxySubscriber.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureFileException.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureFileException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureFileInfo.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureFileInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureManager.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureManagerException.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureManagerException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureServiceException.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureServiceException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureType.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureUpdateService.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/signature/SignatureUpdateService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/text/TextIdentifier.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/text/TextIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/util/DroidUrlFormat.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/util/DroidUrlFormat.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/resources/archive-puids.properties
+++ b/droid-core-interfaces/src/main/resources/archive-puids.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/main/resources/archive-spring.xml
+++ b/droid-core-interfaces/src/main/resources/archive-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArcArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArcArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFileUtilsTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFileUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolverImplTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveFormatResolverImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveHandlerFactoryTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArchiveHandlerFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/BZipArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/BZipArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatReaderTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/FatReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/GZipArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/GZipArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ISOImageArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ISOImageArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarReaderTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/RarReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipReaderTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/SevenZipReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TarArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TarArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TrueZipReaderTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TrueZipReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/WarcArchiveHandlerTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/WarcArchiveHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ZipEntryRequestFactoryTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ZipEntryRequestFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/filter/RestrictionFactoryTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/filter/RestrictionFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/QueryBuilderTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/filter/expressions/QueryBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/hash/MD5HashGeneratorTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/hash/MD5HashGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGeneratorTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA256HashGeneratorTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA256HashGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/CachedBinaryTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/CachedBinaryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequestTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequestTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/TarEntryIdentificationRequestTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/TarEntryIdentificationRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ZipEntryIdentificationRequestTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ZipEntryIdentificationRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/util/DroidUrlFormatTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/util/DroidUrlFormatTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/resources/hash/README.txt
+++ b/droid-core-interfaces/src/test/resources/hash/README.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/resources/log4j2.properties
+++ b/droid-core-interfaces/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/resources/saved/db/service.properties
+++ b/droid-core-interfaces/src/test/resources/saved/db/service.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/resources/saved/profile.xml
+++ b/droid-core-interfaces/src/test/resources/saved/profile.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,7 @@
 -->
 <?xml version="1.0" encoding="UTF-8"?><profiles/><!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-core-interfaces/src/test/resources/testXmlFile.xml
+++ b/droid-core-interfaces/src/test/resources/testXmlFile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-core/checkstyle/suppressions.xml
+++ b/droid-core/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/BinarySignatureIdentifier.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/BinarySignatureIdentifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/IdentificationRequestByteReaderAdapter.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/IdentificationRequestByteReaderAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/SignatureFileParser.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/SignatureFileParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/SignatureParseException.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/SignatureParseException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/ByteReader.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/ByteReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/FileFormat.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/FileFormat.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/FileFormatCollection.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/FileFormatCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/FileFormatHit.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/FileFormatHit.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceAnchor.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceAnchor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceCompiler.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceCompiler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceParser.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceSerializer.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/SignatureType.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/SignatureType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/ByteSequence.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/ByteSequence.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/ByteSequenceComparator.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/ByteSequenceComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/FFSignatureFile.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/FFSignatureFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/FragmentRewriter.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/FragmentRewriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignature.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignatureCollection.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignatureCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignatureComparator.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/InternalSignatureComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/LeftFragment.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/LeftFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/RightFragment.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/RightFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/Shift.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/Shift.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SideFragment.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SideFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SubSequence.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SubSequence.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/xml/SAXModelBuilder.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/xml/SAXModelBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/xml/SimpleElement.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/xml/SimpleElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/xml/XmlUtils.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/xml/XmlUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/main/resources/spring-core.xml
+++ b/droid-core/src/main/resources/spring-core.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/AnyBitmaskBugFixTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/AnyBitmaskBugFixTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/BofEofOffsetBugFixTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/BofEofOffsetBugFixTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/Droid4LegacyDroidTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/Droid4LegacyDroidTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/IdentificationRequestByteWrapperAdapterTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/IdentificationRequestByteWrapperAdapterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/ReverseScanBugFixTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/ReverseScanBugFixTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/SkeletonSuiteTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/SkeletonSuiteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/ThreadPoolExecutorTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/ThreadPoolExecutorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/fragments/LeftFragmentVariableOffsetTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/fragments/LeftFragmentVariableOffsetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/fragments/RightFragmentVariableOffsetTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/fragments/RightFragmentVariableOffsetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceCompilerTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceCompilerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceParserTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceSerializerTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceSerializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/droid6/FragmentRewriterTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/droid6/FragmentRewriterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/checkstyle/suppressions.xml
+++ b/droid-export-interfaces/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ExportJob.java
+++ b/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ExportJob.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ExportManager.java
+++ b/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ExportManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ExportOptions.java
+++ b/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ExportOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ItemReader.java
+++ b/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ItemReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ItemReaderCallback.java
+++ b/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ItemReaderCallback.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ItemWriter.java
+++ b/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/ItemWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/JobCancellationException.java
+++ b/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/JobCancellationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/JobOptions.java
+++ b/droid-export-interfaces/src/main/java/uk/gov/nationalarchives/droid/export/interfaces/JobOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export/checkstyle/suppressions.xml
+++ b/droid-export/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/CsvItemWriter.java
+++ b/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/CsvItemWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/ExportManagerImpl.java
+++ b/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/ExportManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/ExportTask.java
+++ b/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/ExportTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/main/resources/META-INF/export-spring.xml
+++ b/droid-export/src/main/resources/META-INF/export-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/CsvItemWriterTest.java
+++ b/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/CsvItemWriterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/ExportJobIntegrationTest.java
+++ b/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/ExportJobIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/ExportManagerImplTest.java
+++ b/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/ExportManagerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/ExportTaskTest.java
+++ b/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/ExportTaskTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/test/resources/META-INF/spring-export-test.xml
+++ b/droid-export/src/test/resources/META-INF/spring-export-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/test/resources/jpa-test.properties
+++ b/droid-export/src/test/resources/jpa-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-export/src/test/resources/log4j2.properties
+++ b/droid-export/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Change preferences.html
+++ b/droid-help/src/main/resources/Web pages/Change preferences.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Choose files and folders.html
+++ b/droid-help/src/main/resources/Web pages/Choose files and folders.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Command line control.html
+++ b/droid-help/src/main/resources/Web pages/Command line control.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Create a new profile.html
+++ b/droid-help/src/main/resources/Web pages/Create a new profile.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Detecting duplicate files.html
+++ b/droid-help/src/main/resources/Web pages/Detecting duplicate files.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Explore the results.html
+++ b/droid-help/src/main/resources/Web pages/Explore the results.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Exporting profiles.html
+++ b/droid-help/src/main/resources/Web pages/Exporting profiles.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/FAQ.html
+++ b/droid-help/src/main/resources/Web pages/FAQ.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Information collected by DROID.html
+++ b/droid-help/src/main/resources/Web pages/Information collected by DROID.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/License.html
+++ b/droid-help/src/main/resources/Web pages/License.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Load and save profiles.html
+++ b/droid-help/src/main/resources/Web pages/Load and save profiles.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Running a profile.html
+++ b/droid-help/src/main/resources/Web pages/Running a profile.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Startup configuration.html
+++ b/droid-help/src/main/resources/Web pages/Startup configuration.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Summary reporting.html
+++ b/droid-help/src/main/resources/Web pages/Summary reporting.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Third-party components.html
+++ b/droid-help/src/main/resources/Web pages/Third-party components.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Update file format signatures.html
+++ b/droid-help/src/main/resources/Web pages/Update file format signatures.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Welcome to DROID.html
+++ b/droid-help/src/main/resources/Web pages/Welcome to DROID.html
@@ -1,6 +1,6 @@
 ﻿<!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/Web pages/Whats New.html
+++ b/droid-help/src/main/resources/Web pages/Whats New.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/index.xml
+++ b/droid-help/src/main/resources/index.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/map.xml
+++ b/droid-help/src/main/resources/map.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-help/src/main/resources/toc.xml
+++ b/droid-help/src/main/resources/toc.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -81,7 +81,7 @@
         <project.build.target>1.8</project.build.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <project.email>pronom@nationalarchives.gsi.gov.uk</project.email>
+        <project.email>pronom@nationalarchives.gov.uk</project.email>
 
         <spring.version>5.2.2.RELEASE</spring.version>
         <hibernate.version>5.4.1.Final</hibernate.version>

--- a/droid-report-interfaces/checkstyle/suppressions.xml
+++ b/droid-report-interfaces/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/Aggregator.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/Aggregator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/CancellableProgressObserver.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/CancellableProgressObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/GroupedFieldItem.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/GroupedFieldItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ProfileReportData.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ProfileReportData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ProfileSummaryReport.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ProfileSummaryReport.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/Report.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/Report.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportCancelledException.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportCancelledException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportData.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportItem.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportManager.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportRequest.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportSpec.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportSpec.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportSpecDao.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportSpecDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportSpecItem.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportSpecItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportXmlWriter.java
+++ b/droid-report-interfaces/src/main/java/uk/gov/nationalarchives/droid/report/interfaces/ReportXmlWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report-interfaces/src/main/resources/archive-spring.xml
+++ b/droid-report-interfaces/src/main/resources/archive-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/checkstyle/suppressions.xml
+++ b/droid-report/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/report_definitions/All files and folders.out.xml
+++ b/droid-report/report_definitions/All files and folders.out.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/report_definitions/All files and folders.xml
+++ b/droid-report/report_definitions/All files and folders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/JaxbReportSpecDao.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/JaxbReportSpecDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/JaxbReportXmlWriter.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/JaxbReportXmlWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportManagerImpl.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportTransformException.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportTransformException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportTransformer.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportTransformerImpl.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportTransformerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportUtils.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ByFormatType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ByFormatType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ByYearType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ByYearType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/FileProfileType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/FileProfileType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/FormatItemType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/FormatItemType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ObjectFactory.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/ObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/PathsProcessedType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/PathsProcessedType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/YearItemType.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/YearItemType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/package-info.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/domain/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives &lt;mailto:pronom@nationalarchives.gsi.gov.uk/&gt;
+ * Copyright (c) 2016, The National Archives &lt;mailto:pronom@nationalarchives.gov.uk/&gt;
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/xml/PlanetsXMLGenerator.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/planets/xml/PlanetsXMLGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/Comprehensive breakdown.xml
+++ b/droid-report/src/main/resources/Comprehensive breakdown.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/File count and sizes by file extension.xml
+++ b/droid-report/src/main/resources/File count and sizes by file extension.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/File count and sizes by file format PUID.xml
+++ b/droid-report/src/main/resources/File count and sizes by file format PUID.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/File count and sizes by mime type.xml
+++ b/droid-report/src/main/resources/File count and sizes by mime type.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/File count and sizes by month last modified.xml
+++ b/droid-report/src/main/resources/File count and sizes by month last modified.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/File count and sizes by year and month last modified.xml
+++ b/droid-report/src/main/resources/File count and sizes by year and month last modified.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/File count and sizes by year last modified.xml
+++ b/droid-report/src/main/resources/File count and sizes by year last modified.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/File count and sizes.xml
+++ b/droid-report/src/main/resources/File count and sizes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/META-INF/report-spring.xml
+++ b/droid-report/src/main/resources/META-INF/report-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/Planets XML.xml.xsl
+++ b/droid-report/src/main/resources/Planets XML.xml.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/Text.txt.xsl
+++ b/droid-report/src/main/resources/Text.txt.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/Total count of files and folders.xml
+++ b/droid-report/src/main/resources/Total count of files and folders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/Total unreadable files.xml
+++ b/droid-report/src/main/resources/Total unreadable files.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/Total unreadable folders.xml
+++ b/droid-report/src/main/resources/Total unreadable folders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/Web page.html.xsl
+++ b/droid-report/src/main/resources/Web page.html.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/xsd/ReportSpecification.xsd
+++ b/droid-report/src/main/resources/xsd/ReportSpecification.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/xsd/droidFilterSpecification.xsd
+++ b/droid-report/src/main/resources/xsd/droidFilterSpecification.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/xsd/droidReport.xsd
+++ b/droid-report/src/main/resources/xsd/droidReport.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/xsd/droidReportSpecification.xsd
+++ b/droid-report/src/main/resources/xsd/droidReportSpecification.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/xsd/planets.xml
+++ b/droid-report/src/main/resources/xsd/planets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/main/resources/xsd/planets.xsd
+++ b/droid-report/src/main/resources/xsd/planets.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/java/uk/gov/nationalarchives/droid/report/JaxbReportSpecDaoTest.java
+++ b/droid-report/src/test/java/uk/gov/nationalarchives/droid/report/JaxbReportSpecDaoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/java/uk/gov/nationalarchives/droid/report/ReportExportTest.java
+++ b/droid-report/src/test/java/uk/gov/nationalarchives/droid/report/ReportExportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/java/uk/gov/nationalarchives/droid/report/planets/xml/JaxbReportXmlWriterTest.java
+++ b/droid-report/src/test/java/uk/gov/nationalarchives/droid/report/planets/xml/JaxbReportXmlWriterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/java/uk/gov/nationalarchives/droid/report/planets/xml/PlanetsXMLGeneratorTest.java
+++ b/droid-report/src/test/java/uk/gov/nationalarchives/droid/report/planets/xml/PlanetsXMLGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/META-INF/spring-test.xml
+++ b/droid-report/src/test/resources/META-INF/spring-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/droidDbUnit.dtd
+++ b/droid-report/src/test/resources/droidDbUnit.dtd
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/exampleFilter.xml
+++ b/droid-report/src/test/resources/exampleFilter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/exampleProfile.xml
+++ b/droid-report/src/test/resources/exampleProfile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/exampleReport.xml
+++ b/droid-report/src/test/resources/exampleReport.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/exampleReportSpecification.xml
+++ b/droid-report/src/test/resources/exampleReportSpecification.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/jpa-test.properties
+++ b/droid-report/src/test/resources/jpa-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/log4j2.properties
+++ b/droid-report/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/report-test-data-sans-formats.xml
+++ b/droid-report/src/test/resources/report-test-data-sans-formats.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/report-test-data.xml
+++ b/droid-report/src/test/resources/report-test-data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-report/src/test/resources/test-report.xml
+++ b/droid-report/src/test/resources/test-report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/checkstyle/suppressions.xml
+++ b/droid-results/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/nb-configuration.xml
+++ b/droid-results/nb-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/GroupByPuidSizeAndCountRow.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/GroupByPuidSizeAndCountRow.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/GroupByYearSizeAndCountRow.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/GroupByYearSizeAndCountRow.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/JdbcPlanetsXMLDaoImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/JdbcPlanetsXMLDaoImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/PlanetsXMLDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/PlanetsXMLDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/PlanetsXMLData.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/PlanetsXMLData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/ProfileStat.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/planet/xml/dao/ProfileStat.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/AbstractProfileResource.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/AbstractProfileResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/DirectoryProfileResource.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/DirectoryProfileResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FileProfileResource.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FileProfileResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterCriterionImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterCriterionImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterPredicate.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterPredicate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterSpec.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterSpec.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterSpecDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/FilterSpecDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/JDBCProfileDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/JDBCProfileDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/JaxbFilterSpecDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/JaxbFilterSpecDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/JaxbProfileSpecDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/JaxbProfileSpecDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/JobStatus.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/JobStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/NodeMetaData.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/NodeMetaData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ObjectFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileContextLocator.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileContextLocator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileDiskAction.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileDiskAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileEventListener.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileException.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileFileHelper.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileFileHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstance.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstance.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceLocator.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceLocator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceManager.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceManagerImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManager.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManagerException.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManagerException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNode.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileResultObserver.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileResultObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileSpec.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileSpec.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileSpecDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileSpecDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileState.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileUuidGenerator.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileUuidGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileUuidGeneratorImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileUuidGeneratorImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProgressState.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProgressState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/SpringProfileInstanceFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/SpringProfileInstanceFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/SqlUtils.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/SqlUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/UrlProfileResource.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/UrlProfileResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSource.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSourceFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSourceFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/JDBCSqlItemReader.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/JDBCSqlItemReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/Format.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/Format.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceData.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceDataDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceDataDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceDataDaoImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceDataDaoImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceDataService.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceDataService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceDataServiceImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/referencedata/ReferenceDataServiceImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/throttle/SimpleSubmissionThrottle.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/throttle/SimpleSubmissionThrottle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/throttle/SubmissionThrottle.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/throttle/SubmissionThrottle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/DateFieldType.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/DateFieldType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/GroupByField.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/GroupByField.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/NumericFieldType.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/NumericFieldType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/ReportDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/ReportDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/ReportFieldEnum.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/ReportFieldEnum.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/ReportFieldType.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/ReportFieldType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/ReportLineItem.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/ReportLineItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/SqlReportDaoImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/SqlReportDaoImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/StringOrSetFieldType.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/report/dao/StringOrSetFieldType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/JDBCBatchResultHandlerDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/JDBCBatchResultHandlerDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/JDBCResultHandler.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/JDBCResultHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ProgressMonitor.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ProgressMonitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ProgressMonitorImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ProgressMonitorImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ProgressObserver.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ProgressObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ResultHandlerDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ResultHandlerDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ResultQueue.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/results/handlers/ResultQueue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/FormatCallback.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/FormatCallback.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/PronomSignatureService.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/PronomSignatureService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/SaxSignatureFileParser.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/SaxSignatureFileParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/SignatureManagerImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/SignatureManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/SignatureParser.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/signature/SignatureParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/DirectoryEventHandler.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/DirectoryEventHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileEventHandler.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileEventHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileIdentificationRequestFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileIdentificationRequestFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileSystemMissingException.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileSystemMissingException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileWalker.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileWalker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileWalkerHandler.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/FileWalkerHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/JaxBSubmissionQueueDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/JaxBSubmissionQueueDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/JobCounter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/JobCounter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecJobCounter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecJobCounter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecWalker.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecWalker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecWalkerImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecWalkerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileWalkState.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileWalkState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileWalkerDao.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ProfileWalkerDao.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ReplaySubmitter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/ReplaySubmitter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionGateway.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionGateway.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionQueue.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionQueue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionQueueData.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionQueueData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmitterUtils.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmitterUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/util/FileUtil.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/util/FileUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileV1.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileV1.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileV1Response.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileV1Response.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileVersionV1.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileVersionV1.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileVersionV1Response.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/GetSignatureFileVersionV1Response.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/ObjectFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/ObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/PronomService.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/PronomService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/PronomService_Service.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/PronomService_Service.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/Version.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/Version.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/package-info.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives &lt;mailto:pronom@nationalarchives.gsi.gov.uk/&gt;
+ * Copyright (c) 2016, The National Archives &lt;mailto:pronom@nationalarchives.gov.uk/&gt;
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/ObjectFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/ObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/XmlFragment.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/XmlFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/package-info.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/pronom/signaturefile/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives &lt;mailto:pronom@nationalarchives.gsi.gov.uk/&gt;
+ * Copyright (c) 2016, The National Archives &lt;mailto:pronom@nationalarchives.gov.uk/&gt;
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/META-INF/persistence.xml
+++ b/droid-results/src/main/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/META-INF/spring-jpa.xml
+++ b/droid-results/src/main/resources/META-INF/spring-jpa.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/META-INF/spring-profile.xml
+++ b/droid-results/src/main/resources/META-INF/spring-profile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/META-INF/spring-results.xml
+++ b/droid-results/src/main/resources/META-INF/spring-results.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/META-INF/spring-signature.xml
+++ b/droid-results/src/main/resources/META-INF/spring-signature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/archive-puids.properties
+++ b/droid-results/src/main/resources/archive-puids.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/default_droid.properties
+++ b/droid-results/src/main/resources/default_droid.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/import.sql
+++ b/droid-results/src/main/resources/import.sql
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+-- Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 -- All rights reserved.
 --
 -- Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/main/resources/jpa.properties
+++ b/droid-results/src/main/resources/jpa.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/RuntimeConfigTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/RuntimeConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/planet/xml/dao/JpaPlanetsXMLDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/planet/xml/dao/JpaPlanetsXMLDaoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileDaoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileFilterTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/JpaProfileFilterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileDiskActionTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileDiskActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceManagerTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileInstanceManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerIntegrationTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNodePersistenceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNodePersistenceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileSpecToXmlPersistenceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileSpecToXmlPersistenceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/SqlUtilsTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/SqlUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/config/DroidGlobalConfigTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/config/DroidGlobalConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/throttle/SimpleSubmissionThrottleTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/throttle/SimpleSubmissionThrottleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/report/dao/JpaReportDaoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/results/DbUnitDtdGenerator.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/results/DbUnitDtdGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/results/handlers/ProgressMonitorTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/results/handlers/ProgressMonitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/signature/PronomSignatureServiceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/signature/PronomSignatureServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/signature/SignatureFileParserTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/signature/SignatureFileParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/signature/SignatureManagerImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/signature/SignatureManagerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/DirectoryEventHandlerTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/DirectoryEventHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/FileEventHandlerTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/FileEventHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/FileWalkerPersistenceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/FileWalkerPersistenceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/FileWalkerTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/FileWalkerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecWalkerImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecWalkerImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/SubmissionGatewayTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/SubmissionGatewayTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/util/FileUtilTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/util/FileUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/META-INF/mappings.xml
+++ b/droid-results/src/test/resources/META-INF/mappings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/META-INF/spring-test.xml
+++ b/droid-results/src/test/resources/META-INF/spring-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/droidDbUnit.dtd
+++ b/droid-results/src/test/resources/droidDbUnit.dtd
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/jpa-test.properties
+++ b/droid-results/src/test/resources/jpa-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/log4j2.properties
+++ b/droid-results/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/testXmlFile.xml
+++ b/droid-results/src/test/resources/testXmlFile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/uk/gov/nationalarchives/droid/planet/xml/dao/planets-xml-test-data-sans-formats.xml
+++ b/droid-results/src/test/resources/uk/gov/nationalarchives/droid/planet/xml/dao/planets-xml-test-data-sans-formats.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/uk/gov/nationalarchives/droid/planet/xml/dao/planets-xml-test-data.xml
+++ b/droid-results/src/test/resources/uk/gov/nationalarchives/droid/planet/xml/dao/planets-xml-test-data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/uk/gov/nationalarchives/droid/profile/results-test-data-sans-formats.xml
+++ b/droid-results/src/test/resources/uk/gov/nationalarchives/droid/profile/results-test-data-sans-formats.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/uk/gov/nationalarchives/droid/profile/results-test-data.xml
+++ b/droid-results/src/test/resources/uk/gov/nationalarchives/droid/profile/results-test-data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/uk/gov/nationalarchives/droid/report/dao/report-test-data-sans-formats.xml
+++ b/droid-results/src/test/resources/uk/gov/nationalarchives/droid/report/dao/report-test-data-sans-formats.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/src/test/resources/uk/gov/nationalarchives/droid/report/dao/report-test-data.xml
+++ b/droid-results/src/test/resources/uk/gov/nationalarchives/droid/report/dao/report-test-data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-results/wsdl/pronom.wsdl.xml
+++ b/droid-results/wsdl/pronom.wsdl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/checkstyle/suppressions.xml
+++ b/droid-swing-ui/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/nb-configuration.xml
+++ b/droid-swing-ui/nb-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/nbactions.xml
+++ b/droid-swing-ui/nbactions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/org/netbeans/swing/outline/TreePathSupport.java
+++ b/droid-swing-ui/src/main/java/org/netbeans/swing/outline/TreePathSupport.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/CheckListCellModel.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/CheckListCellModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/CheckListRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/CheckListRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DialogUtils.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DialogUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidSplashScreen.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidSplashScreen.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidUIContext.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidUIContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ExitListener.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ExitListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/GlobalContext.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/GlobalContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/MultiIdentificationDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/MultiIdentificationDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileForm.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileTabComponent.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/ProfileTabComponent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/SaveAllProfilesDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/SaveAllProfilesDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/SpringGuiContext.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/SpringGuiContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/ActionDoneCallback.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/ActionDoneCallback.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/ActionFactory.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/ActionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/AddFilesAndFoldersAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/AddFilesAndFoldersAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/ApplyFilterToTreeTableAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/ApplyFilterToTreeTableAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/CloseProfileAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/CloseProfileAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/ExitAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/ExitAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/LoadProfileWorker.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/LoadProfileWorker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/NewProfileAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/NewProfileAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/OpenContainingFolderAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/OpenContainingFolderAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/RemoveFilesAndFoldersAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/RemoveFilesAndFoldersAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/SaveProfileWorker.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/SaveProfileWorker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/StopAJobAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/StopAJobAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/StopRunningProfilesAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/action/StopRunningProfilesAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/InstallSignatureFileAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/InstallSignatureFileAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ListSignatureFilesAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ListSignatureFilesAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/SignatureInstallDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/SignatureInstallDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/UpdateProxyConfigDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/UpdateProxyConfigDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/event/ButtonManager.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/event/ButtonManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportFileChooser.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportFileChooser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportProgressDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportProgressDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ProfileFileChooser.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ProfileFileChooser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceChooserButtonPanel.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceChooserButtonPanel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceDialogUtil.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceDialogUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceFileChooser.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceFileChooser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceTreeWillExpandListener.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceTreeWillExpandListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/DatePicker.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/DatePicker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterFileChooser.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterFileChooser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterTable.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/JComponentCellEditor.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/JComponentCellEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/JComponentCellRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/JComponentCellRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/TextBoxAndButton.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/TextBoxAndButton.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/ValuesDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/ValuesDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/action/ApplyFilterAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/action/ApplyFilterAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/action/InitialiseFilterAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/action/InitialiseFilterAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/action/LoadFilterAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/action/LoadFilterAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/DummyMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/DummyMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/ExtensionMismatchMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/ExtensionMismatchMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FileExtensionMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FileExtensionMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FileFormatMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FileFormatMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FileNameMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FileNameMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FileSizeMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FileSizeMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FilterDomain.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FilterDomain.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FilterValidationException.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FilterValidationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FormatCountMetaData.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/FormatCountMetaData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/GenericMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/GenericMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/IdentificationMethodMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/IdentificationMethodMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/JobStatusMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/JobStatusMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/LastModifiedDateMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/LastModifiedDateMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/Metadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/Metadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/MimeTypeMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/MimeTypeMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/PUIDMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/PUIDMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/ResourceTypeMetadata.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/domain/ResourceTypeMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/help/ExternalLinkContentViewerUI.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/help/ExternalLinkContentViewerUI.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/listeners/NodeSelectionListener.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/listeners/NodeSelectionListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ExportReportAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ExportReportAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportProgressDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportProgressDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportViewFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportViewFrame.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/signature/CheckSignatureUpdateAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/signature/CheckSignatureUpdateAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/signature/SignatureUpdateProgressDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/signature/SignatureUpdateProgressDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/signature/UpdateSignatureAction.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/signature/UpdateSignatureAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DefaultCellRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DefaultCellRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DefaultMutableTreeNodeComparator.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DefaultMutableTreeNodeComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparable.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableDate.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableDate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableEnum.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableEnum.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableFilename.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableFilename.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableLong.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableLong.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableObject.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableString.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparableString.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparator.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/DirectoryComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ExpandingTreeListener.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ExpandingTreeListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/FileExtensionRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/FileExtensionRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/FileSizeRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/FileSizeRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/FormatCountRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/FormatCountRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/HyperlinkRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/HyperlinkRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/NodeRenderer.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/NodeRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/OutlineColumn.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/OutlineColumn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/OutlineComparableComparator.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/OutlineComparableComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ProfileRowModel.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/ProfileRowModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/TreeUtils.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/treemodel/TreeUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/util/DroidStringUtils.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/util/DroidStringUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/FileChooserProxy.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/FileChooserProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/FileChooserProxyImpl.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/FileChooserProxyImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/JOptionPaneProxy.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/JOptionPaneProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/ProfileSelectionDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/ProfileSelectionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/SaveAsFileChooser.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/widgetwrapper/SaveAsFileChooser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/worker/DroidJob.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/worker/DroidJob.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/planets/gui/PlanetXMLFileFilter.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/planets/gui/PlanetXMLFileFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/planets/gui/PlanetXMLProgressDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/planets/gui/PlanetXMLProgressDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/planets/gui/PlanetsXMLGenerationSwingWorker.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/planets/gui/PlanetsXMLGenerationSwingWorker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/META-INF/gui-spring.xml
+++ b/droid-swing-ui/src/main/resources/META-INF/gui-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/log4j2.properties
+++ b/droid-swing-ui/src/main/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/Bundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/config/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/config/Bundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/export/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/export/Bundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/filechooser/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/filechooser/Bundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/filter/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/filter/Bundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/report/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/report/Bundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/signature/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/signature/Bundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/planets/gui/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/planets/gui/Bundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/LoadProfileWorkerTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/LoadProfileWorkerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/ProfileFormTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/ProfileFormTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/SaveAllProfilesDialogTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/SaveAllProfilesDialogTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/action/CloseProfileActionTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/action/CloseProfileActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/action/ExitActionTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/action/ExitActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/config/ConfigActionTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/config/ConfigActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialogTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialogTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/filechooser/ProfileFileChooserTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/filechooser/ProfileFileChooserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceFileChooserTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceFileChooserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/signature/UpdateSignatureActionTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/signature/UpdateSignatureActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/util/DroidStringUtilsTest.java
+++ b/droid-swing-ui/src/test/java/uk/gov/nationalarchives/droid/gui/util/DroidStringUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-swing-ui/src/test/resources/log4j2.properties
+++ b/droid-swing-ui/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+# Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/droid-tools/checkstyle/suppressions.xml
+++ b/droid-tools/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+    Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/droid-tools/src/main/java/uk/gov/nationalarchives/droid/tools/SigTool.java
+++ b/droid-tools/src/main/java/uk/gov/nationalarchives/droid/tools/SigTool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/droid-tools/src/main/java/uk/gov/nationalarchives/droid/tools/SigUtils.java
+++ b/droid-tools/src/main/java/uk/gov/nationalarchives/droid/tools/SigUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Updated the email signature in headers across the codebase. The changes include 
1) Update to the text file used by license plugin
2) Updates to the actual headers wherever it appeared (in Java, xml, properties, xsd and wsdl files). 

UPDATE Jeremie:
fix https://github.com/digital-preservation/droid/issues/286