### PR TITLE
Introduced the jUnit TemporaryFolder rule for automatic cleanup of fi…

### DIFF
--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ExportCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ExportCommandTest.java
@@ -31,27 +31,13 @@
  */
 package uk.gov.nationalarchives.droid.command.action;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Future;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
-
-import uk.gov.nationalarchives.droid.command.filter.SimpleDqlFilterParser;
 import uk.gov.nationalarchives.droid.command.filter.CommandLineFilter;
 import uk.gov.nationalarchives.droid.command.filter.CommandLineFilter.FilterType;
+import uk.gov.nationalarchives.droid.command.filter.SimpleDqlFilterParser;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionFieldEnum;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionOperator;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.Filter;
@@ -62,17 +48,33 @@ import uk.gov.nationalarchives.droid.profile.ProfileInstance;
 import uk.gov.nationalarchives.droid.profile.ProfileManager;
 import uk.gov.nationalarchives.droid.results.handlers.ProgressObserver;
 
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 /**
  * @author rflitcroft
  *
  */
 public class ExportCommandTest {
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     @Test
     public void testExportThreeProfiles() throws Exception {
-        
-        final String destination = Files.createTempFile("droid", "exportCommandTest").toAbsolutePath().toString();
-        
+        final String destination = temporaryFolder.newFile("exportCommandTest").getAbsolutePath();
+
         ExportManager exportManager = mock(ExportManager.class);
         ProfileManager profileManager = mock(ProfileManager.class);
         
@@ -108,7 +110,6 @@ public class ExportCommandTest {
         };
         
         verify(exportManager).exportProfiles(Arrays.asList(expectedExportedProfiles), destination, null, ExportOptions.ONE_ROW_PER_FORMAT, "UTF-8", false);
-        
     }
 
     @Test
@@ -144,8 +145,7 @@ public class ExportCommandTest {
         
         command.setFilter(cliFilter);
         command.execute();
-        
-        
+
         String[] expectedExportedProfiles = new String[] {
             "profile1",
         };
@@ -154,7 +154,6 @@ public class ExportCommandTest {
         verify(exportManager).exportProfiles(eq(Arrays.asList(expectedExportedProfiles)), 
                 eq("destination"), filterCaptor.capture(), eq(ExportOptions.ONE_ROW_PER_FORMAT), any(String.class), eq(false));
 
-        
         Filter filter = filterCaptor.getValue();
         final List<FilterCriterion> criteria = filter.getCriteria();
         assertEquals(2, criteria.size());

--- a/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/ExportTaskTest.java
+++ b/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/ExportTaskTest.java
@@ -32,18 +32,21 @@
 package uk.gov.nationalarchives.droid.export;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import uk.gov.nationalarchives.droid.export.interfaces.ItemWriter;
 
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 
 /**
  * @author Adam Retter
@@ -51,34 +54,37 @@ import static org.mockito.Mockito.*;
  */
 public class ExportTaskTest {
 
-    static ItemWriter itemWriter;
-    static Path tempFile;
+    ItemWriter itemWriter;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Before
     public void setup() throws IOException {
         itemWriter = mock(ItemWriter.class);
-        tempFile = Files.createTempFile("droid", "export-task-test");
     }
 
     @Test
     public void testEncodingDefault() throws IOException {
-        final String destination = tempFile.toAbsolutePath().toString();
+        File tempFile = temporaryFolder.newFile("export-task-test-default-encoding");
+        final String destination = tempFile.getAbsolutePath();
         final String encoding = null; //i.e. platform dependent
 
         final ExportTask pmExportTask = spy(new ExportTask(destination, new ArrayList<String>(), null, null, encoding, false, itemWriter, null));
         pmExportTask.run();
 
-        verify(pmExportTask, never()).newOutputFileWriterEncoded(encoding, tempFile);
+        verify(pmExportTask, never()).newOutputFileWriterEncoded(encoding, tempFile.toPath());
     }
 
     @Test
     public void testEncodingSpecific() throws IOException {
-        final String destination = tempFile.toAbsolutePath().toString();
+        File tempFile = temporaryFolder.newFile("export-task-test-specific-encoding");
+        final String destination = tempFile.getAbsolutePath();
         final String encoding = "UTF-8";
 
         final ExportTask pmExportTask = spy(new ExportTask(destination, new ArrayList<String>(), null, null, encoding, false, itemWriter, null));
         pmExportTask.run();
 
-        verify(pmExportTask, times(1)).newOutputFileWriterEncoded(encoding, tempFile);
+        verify(pmExportTask, times(1)).newOutputFileWriterEncoded(encoding, tempFile.toPath());
     }
 }


### PR DESCRIPTION
…les created during tests

The cleanup should happen automatically. 
For testing, you could build it locally and make sure that no additional files appear within the source tree. Also check that no additional files appear under the 'tmp' folder. 

Also cleaned up imports and removed unwanted static declaration 