### PR TITLE
fix logging

### DIFF
--- a/droid-command-line/pom.xml
+++ b/droid-command-line/pom.xml
@@ -66,7 +66,12 @@
                                 <ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>javax.xml.bind:jaxb-api</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>com.sun.activation:javax.activation</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>org.slf4j:slf4j-api</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>jakarta.xml.bind:jakarta.xml.bind-api</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>
@@ -165,8 +170,8 @@
             <scope>runtime</scope>
   	    </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/droid-command-line/src/main/resources/META-INF/cxf/org.apache.cxf.Logger
+++ b/droid-command-line/src/main/resources/META-INF/cxf/org.apache.cxf.Logger
@@ -1,1 +1,1 @@
-org.apache.cxf.common.logging.Log4jLogger
+org.apache.cxf.common.logging.Slf4jLogger

--- a/droid-command-line/src/main/resources/log4j2.properties
+++ b/droid-command-line/src/main/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.rolling.layout.pattern = %d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 appender.rolling.policies.type = Policies
 appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-command-line/src/test/resources/log4j2.properties
+++ b/droid-command-line/src/test/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.console.layout.pattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 #appender.rolling.policies.type = Policies
 #appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 #rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-container/pom.xml
+++ b/droid-container/pom.xml
@@ -64,9 +64,9 @@
             <artifactId>droid-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+                <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>

--- a/droid-container/src/test/resources/log4j2.properties
+++ b/droid-container/src/test/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.console.layout.pattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 #appender.rolling.policies.type = Policies
 #appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 #rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -54,9 +54,9 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+                <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.java-iso-tools</groupId>

--- a/droid-core-interfaces/src/test/resources/log4j2.properties
+++ b/droid-core-interfaces/src/test/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.console.layout.pattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 #appender.rolling.policies.type = Policies
 #appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 #rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-core/pom.xml
+++ b/droid-core/pom.xml
@@ -54,9 +54,9 @@
     </build>
   
     <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+                <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>

--- a/droid-export/pom.xml
+++ b/droid-export/pom.xml
@@ -55,8 +55,8 @@
   
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>

--- a/droid-export/src/test/resources/log4j2.properties
+++ b/droid-export/src/test/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.console.layout.pattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 #appender.rolling.policies.type = Policies
 #appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 #rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -239,8 +239,10 @@
                                 <ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>javax.xml.bind:jaxb-api</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.bouncycastle:bcprov-jdk15on</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                             <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>org.slf4j:slf4j-api</ignoredUsedUndeclaredDependency>
                                 <ignoredUsedUndeclaredDependency>jakarta.xml.bind:jakarta.xml.bind-api</ignoredUsedUndeclaredDependency>
                             </ignoredUsedUndeclaredDependencies>
                         </configuration>

--- a/droid-report/pom.xml
+++ b/droid-report/pom.xml
@@ -55,8 +55,8 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>

--- a/droid-report/src/test/resources/log4j2.properties
+++ b/droid-report/src/test/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.console.layout.pattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 #appender.rolling.policies.type = Policies
 #appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 #rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -112,8 +112,10 @@
 								<ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>com.sun.activation:javax.activation</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
 							</ignoredUnusedDeclaredDependencies>
 							<ignoredUsedUndeclaredDependencies>
+								<ignoredUsedUndeclaredDependency>org.slf4j:slf4j-api</ignoredUsedUndeclaredDependency>
 								<ignoredUsedUndeclaredDependency>stax:stax-api</ignoredUsedUndeclaredDependency>
 							</ignoredUsedUndeclaredDependencies>
 						</configuration>
@@ -227,6 +229,10 @@
 			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
 		</dependency>
@@ -296,10 +302,10 @@
 			<artifactId>HikariCP-java7</artifactId>
 			<version>2.4.13</version>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
+		        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/droid-results/src/test/resources/log4j2.properties
+++ b/droid-results/src/test/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.console.layout.pattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 #appender.rolling.policies.type = Policies
 #appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 #rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-swing-ui/pom.xml
+++ b/droid-swing-ui/pom.xml
@@ -66,7 +66,11 @@
                                 <ignoredUnusedDeclaredDependency>uk.gov.nationalarchives:droid-help:jar:${project.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>com.sun.activation:javax.activation</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>org.slf4j:slf4j-api</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>
@@ -178,8 +182,8 @@
             <version>1.2.1</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/droid-swing-ui/src/main/resources/META-INF/cxf/org.apache.cxf.Logger
+++ b/droid-swing-ui/src/main/resources/META-INF/cxf/org.apache.cxf.Logger
@@ -1,1 +1,1 @@
-org.apache.cxf.common.logging.Log4jLogger
+org.apache.cxf.common.logging.Slf4jLogger

--- a/droid-swing-ui/src/main/resources/log4j2.properties
+++ b/droid-swing-ui/src/main/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.rolling.layout.pattern = %d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 appender.rolling.policies.type = Policies
 appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-swing-ui/src/test/resources/log4j2.properties
+++ b/droid-swing-ui/src/test/resources/log4j2.properties
@@ -45,7 +45,7 @@ appender.console.layout.pattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 #appender.rolling.policies.type = Policies
 #appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRef.console.ref= console
 #rootLogger.appenderRef.rolling.ref= rolling
 

--- a/droid-tools/pom.xml
+++ b/droid-tools/pom.xml
@@ -115,8 +115,8 @@
             <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# Issue
The logging is broken and shows this kind of logs when starting the app or running some unit tests.
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

Another type of log was mentioned at startup stating "Starting service Pronom[...]"

# Context
Introduced in PR https://github.com/digital-preservation/droid/pull/352 on commit ccd5a6c534a06d76e49250940673a4b13240176b while fixing dependency check issues.

# Fix
- put back log4j slf4j binding dependency in all modules ran or having unit tests
- tell apache.cxf to use slf4j instead of log4j (was using log4j1 and ignoring log4j2 config)
- set root logger to warn (since it's overridden on tna logs to INFO or whatever the user asks)

# Acceptance tests
## on unit tests
- run mvn install
- check above logs do not appear anymore
## while running droid apps
- GUI
just start the GUI
- CLI 
`./droid.sh -h` is enough
