### PR TITLE
Ensure only a single object is created.

### DIFF
--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSourceFactory.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSourceFactory.java
@@ -138,7 +138,7 @@ public class DerbyPooledDataSourceFactory implements FactoryBean<DerbyPooledData
 
     @Override
     public boolean isSingleton() {
-        return false;
+        return true;
     }
 
 


### PR DESCRIPTION
Ensures the factory only creates a single pool per application context.