### PR TITLE
fix: format version and name was not given anymore in exports

### DIFF
--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -302,10 +302,6 @@
 			<artifactId>HikariCP-java7</artifactId>
 			<version>2.4.13</version>
 		</dependency>
-		        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/JDBCSqlItemReader.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/export/JDBCSqlItemReader.java
@@ -71,6 +71,9 @@ public class JDBCSqlItemReader<T> implements ItemReader<T> {
     private static final String PUID = "PUID";
     private static final String NODE_ID = "NODE_ID";
     private static final String NAME = "NAME";
+    private static final String MIME_TYPE = "MIME_TYPE";
+    private static final String VERSION = "VERSION";
+
     private static final String EMPTY_FOLTER_SUBSELECT = " CASE \n"
             + "\t\t  WHEN p.RESOURCE_TYPE = 0 THEN \n"
             + "\t\t  \tCASE\n"
@@ -406,11 +409,10 @@ public class JDBCSqlItemReader<T> implements ItemReader<T> {
                     SELECT_FORMATS,
                     (rs, rowNum) -> {
                         Format format = new Format();
-                        String puid = rs.getString(PUID);
-                        format.setPuid(puid);
-                        format.setMimeType(rs.getString("MIME_TYPE"));
-                        format.setName(NAME);
-                        format.setVersion("VERSION");
+                        format.setPuid(rs.getString(PUID));
+                        format.setMimeType(rs.getString(MIME_TYPE));
+                        format.setName(rs.getString(NAME));
+                        format.setVersion(rs.getString(VERSION));
                         return format;
                     });
 


### PR DESCRIPTION
# issue
from @dclipsham: one thing i picked up on with the build @Jeremie gave to me - when exporting the CSV, the format identifier columns were not correct - no PUID, name or version listed. I gotta leave now but can replicate tomorrow if needed
https://github.com/digital-preservation/droid/issues/360

# context
introduced on https://github.com/digital-preservation/droid/pull/212 745cc37d0bfcaf5f0f3229bf5a6c2b8e34bb59fa

# solution
put back previous code where we retrieve name and version from jdbc query (rather than constant)

# Acceptance test
- run analysis of a folder on GUI
- make an export
- check that version and name columns are now provided in the export