### PR TITLE
Only log hikari errors.

### DIFF
--- a/droid-binary/conf/log4j2.properties
+++ b/droid-binary/conf/log4j2.properties
@@ -77,5 +77,6 @@ log4j.category.org.springframework=ERROR
 log4j.category.org.hibernate=ERROR
 log4j.logger.org.springframework=ERROR
 log4j.logger.org.hibernate=ERROR
+log4j.category.com.zaxxer.hikari=ERROR
 
 

--- a/droid-swing-ui/src/main/resources/log4j2.properties
+++ b/droid-swing-ui/src/main/resources/log4j2.properties
@@ -70,5 +70,8 @@ logger.apache.level=error
 logger.apache.appenderRef.console.ref = console
 logger.apache.appenderRef.rolling.ref = rolling
 
-
+logger.hikari.name=com.zaxxer.hikari
+logger.hikari.level=error
+logger.hikari.appenderRef.console.ref = console
+logger.hikari.appenderRef.rolling.ref = rolling
 


### PR DESCRIPTION
  * removes noise from the main DROID log in normal operation.

Note: you won't see these changes unless you get rid of your .droid6 folder.  If you have an existing installation, DROID will continue to use the previous log4j2.properties file already installed.