### PR TITLE
fix: CLI can browse again folders recursively

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -128,7 +128,7 @@ public class NoProfileRunCommand implements DroidCommand {
                                 }
                             }
                         }
-                        return false;
+                        return true;
                     }
                 };
 

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/util/FileUtil.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/util/FileUtil.java
@@ -311,9 +311,10 @@ public final class FileUtil {
 
         try {
             for (final Path child : dirStream) {
-                results.add(child);
                 if (recursive && Files.isDirectory(child)) {
                     listFiles(child, recursive, filter, results);
+                } else {
+                    results.add(child);
                 }
             }
         } finally {


### PR DESCRIPTION
# Issue
Tried using the -R flag to recurse folders ./droid.sh -Nr "/home/saurabh/test-data/warc" -Ns "DROID_SignatureFile_V96.xml" -Wt WARC -R
---- It did not recurse the folders underneath which also had WARC files

fix https://github.com/digital-preservation/droid/issues/363

# Context
bug introduced in droid/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java on commit 0d3cbe2 from #167

# Acceptance tests
- run CLI on folder containing sub folders
with following arguments (adapt to your workspace)

```
-R
-Nr
/boot/grub
-Ns
/home/jeremie/.droid6/signature_files/DROID_SignatureFile_V91.xml
-Nc
/home/jeremie/.droid6/container_sigs/container-signature-20170330.xml
```

- verify CLI processed sub folders