### PR TITLE
Fix skeleton issue 

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/ArchiveContentIdentifier.java
@@ -60,6 +60,10 @@ public abstract class ArchiveContentIdentifier {
     protected String path;
     private ArchiveConfiguration archiveConfiguration;
 
+    protected static final String START_PARENTHESIS = " (";
+    protected static final String END_PARENTHESIS = ")";
+
+
     /**
      * Initialization of instance values must be explicitly called by all children.
      * @param binarySignatureIdentifier     binary signature identifier

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
@@ -57,9 +57,6 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
 
     private static final long SIZE = 12L;
     private static final long TIME = 13L;
-    private static final String START_PARENTHESIS = " (";
-    private static final String END_PARENTHESIS = ")";
-
 
     /**
      *

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
@@ -112,15 +112,15 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
             if (bzipIn != null) {
                 try {
                     bzipIn.close();
-                } catch (IOException ioe) {
-                    throw new CommandExecutionException(ioe.getMessage(), ioe);
+                } catch (IOException e) {
+                    System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
                 }
             }
             if (bzRequest != null) {
                 try {
                     bzRequest.close();
-                } catch (IOException ioe) {
-                    throw new CommandExecutionException(ioe.getMessage(), ioe);
+                } catch (IOException e) {
+                    System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
                 }
             }
         }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/Bzip2ArchiveContentIdentifier.java
@@ -57,6 +57,8 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
 
     private static final long SIZE = 12L;
     private static final long TIME = 13L;
+    private static final String START_PARENTHESIS = " (";
+    private static final String END_PARENTHESIS = ")";
 
 
     /**
@@ -107,20 +109,20 @@ public class Bzip2ArchiveContentIdentifier extends ArchiveContentIdentifier {
                     containerSignatureDefinitions, newPath, slash, slash1, super.getArchiveConfiguration());
             resultPrinter.print(bzResults, bzRequest);
         } catch (IOException ioe) {
-            System.err.println(ioe + " (" + newPath + ")"); // continue after corrupt archive
+            System.err.println(ioe + START_PARENTHESIS + newPath + END_PARENTHESIS); // continue after corrupt archive
         } finally {
             if (bzipIn != null) {
                 try {
                     bzipIn.close();
                 } catch (IOException e) {
-                    System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
+                    System.err.println(e + START_PARENTHESIS + newPath + END_PARENTHESIS); // continue after corrupt archive
                 }
             }
             if (bzRequest != null) {
                 try {
                     bzRequest.close();
                 } catch (IOException e) {
-                    System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
+                    System.err.println(e + START_PARENTHESIS + newPath + END_PARENTHESIS); // continue after corrupt archive
                 }
             }
         }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
@@ -94,7 +94,9 @@ public class IsoArchiveContainerIdentifier extends ArchiveContentIdentifier {
                         processEntry(entry, uri, fileSystem, newPath);
                     }
                 }
+            //CHECKSTYLE:OFF we have to ignore the RuntimeException when dealing with corrupted files
             } catch (IOException | RuntimeException e) {
+            //CHECKSTYLE:ON
                 System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
             }
         } else {

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
@@ -97,7 +97,7 @@ public class IsoArchiveContainerIdentifier extends ArchiveContentIdentifier {
             //CHECKSTYLE:OFF we have to ignore the RuntimeException when dealing with corrupted files
             } catch (IOException | RuntimeException e) {
             //CHECKSTYLE:ON
-                System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
+                System.err.println(e + START_PARENTHESIS + newPath + END_PARENTHESIS); // continue after corrupt archive
             }
         } else {
             log.info("Identification request for ISO image ignored due to limited support.");

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
@@ -94,8 +94,8 @@ public class IsoArchiveContainerIdentifier extends ArchiveContentIdentifier {
                         processEntry(entry, uri, fileSystem, newPath);
                     }
                 }
-            } catch (IOException e) {
-                throw new CommandExecutionException("IO error in ISOFileSystem", e);
+            } catch (IOException | RuntimeException e) {
+                System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
             }
         } else {
             log.info("Identification request for ISO image ignored due to limited support.");

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
@@ -103,10 +103,8 @@ public class RarArchiveContainerIdentifier extends ArchiveContentIdentifier {
                         }
                     }
                 }
-            } catch (IOException e) {
-                throw new CommandExecutionException("IO error in RARFileSystem", e);
-            } catch (RarException ex) {
-                throw new CommandExecutionException("Rar exception in RARFileSystem", ex);
+            } catch (RarException | IOException e) {
+                System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
             }
         } else {
             log.info("Identification request for RAR archive ignored due to limited support.");

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/RarArchiveContainerIdentifier.java
@@ -104,7 +104,7 @@ public class RarArchiveContainerIdentifier extends ArchiveContentIdentifier {
                     }
                 }
             } catch (RarException | IOException e) {
-                System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
+                System.err.println(e + START_PARENTHESIS + newPath + END_PARENTHESIS); // continue after corrupt archive
             }
         } else {
             log.info("Identification request for RAR archive ignored due to limited support.");

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
@@ -98,7 +98,7 @@ public class SevenZipArchiveContainerIdentifier extends ArchiveContentIdentifier
                     }
                 }
             } catch (IOException e) {
-                System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
+                System.err.println(e + START_PARENTHESIS + newPath + END_PARENTHESIS); // continue after corrupt archive
             }
         } else {
             log.info("Identification request for 7z archive ignored due to limited support.");

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/SevenZipArchiveContainerIdentifier.java
@@ -98,7 +98,7 @@ public class SevenZipArchiveContainerIdentifier extends ArchiveContentIdentifier
                     }
                 }
             } catch (IOException e) {
-                throw new CommandExecutionException("IO error in 7z FileSystem", e);
+                System.err.println(e + " (" + newPath + ")"); // continue after corrupt archive
             }
         } else {
             log.info("Identification request for 7z archive ignored due to limited support.");

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArcArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/ArcArchiveHandler.java
@@ -130,6 +130,7 @@ public class ArcArchiveHandler extends WebArchiveHandler implements ArchiveHandl
                         base = this.iterator.next();
                     } else {
                         base = null;
+                        break;
                     }
                 }
             }

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/BZipIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/BZipIdentificationRequest.java
@@ -100,7 +100,9 @@ public class BZipIdentificationRequest implements IdentificationRequest<InputStr
      */
     @Override
     public final void close() throws IOException {
-        reader.close();
+        if (reader != null) {
+            reader.close();
+        }
     }
 
     /**

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequest.java
@@ -100,7 +100,9 @@ public class GZipIdentificationRequest implements IdentificationRequest<InputStr
      */
     @Override
     public final void close() throws IOException {
-        reader.close();
+        if (reader != null) {
+            reader.close();
+        }
     }
     
     /**


### PR DESCRIPTION
# Issue
since latest work on CLI and GUI on managing archives and web archives, we couldn't run the CLI or GUI on the skeleton suite without disabling expansion of sub-archives.

multiple failures on skeleton suite files (which are valid regarding signatures, but not actually valid files that you can open, so we can consider them as corrupted), due to multiple reasons:
- the difference in the management of different formats (some raise exceptions, some just log the error)
- null pointer exception when trying to close the reader on non-existing subfiles

# Context
fix https://github.com/digital-preservation/droid/issues/371
fix another bug previously identified: bug: CLI on skeleton suite throws NPE on Bzip2 embedded archive

depends on https://github.com/digital-preservation/droid/pull/376 because it makes testing simpler

# Solution
only log error when processing corrupted files
prevent NPE on reader closing

# Acceptance tests
### Run on fixed DROID and export results
- run CLI on skeleton folder in repository droid/droid-core/test-skeletons
- run GUI on skeleton folder
- compare exports CLI vs GUI and check there is no difference
### Run on Droid 6.4 and export results
- run Cli and export
- run GUI and export
- compare exports CLI vs GUI and check there is no difference
### Compare exports
- compare export GUI on Fixed DROID vs 6.4
- compare export CLI on Fixed DROID vs 6.4