### PR TITLE
fix export dialog

### DIFF
--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
@@ -1547,6 +1547,7 @@ public class DroidMainFrame extends JFrame {
                     public void done(ExportAction action) {
                         try {
                             exportDialog.setVisible(false);
+                            exportDialog.dispose();
                             action.get();
                             JOptionPane.showMessageDialog(DroidMainFrame.this, "Export Complete.", "Export Complete",
                                     JOptionPane.INFORMATION_MESSAGE);

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.form
@@ -129,7 +129,7 @@
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="cancelButton" alignment="3" min="-2" pref="23" max="-2" attributes="0"/>
+                      <Component id="cancelButton" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="exportButton" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="cmdEncoding" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.java
@@ -276,8 +276,7 @@ public class ExportDialog extends JDialog {
 
         GroupLayout jPanel1Layout = new GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
-        jPanel1Layout.setHorizontalGroup(
-            jPanel1Layout.createParallelGroup(Alignment.LEADING)
+        jPanel1Layout.setHorizontalGroup(jPanel1Layout.createParallelGroup(Alignment.LEADING)
             .addGroup(jPanel1Layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(jPanel1Layout.createParallelGroup(Alignment.LEADING)
@@ -296,15 +295,14 @@ public class ExportDialog extends JDialog {
                         .addGap(0, 145, Short.MAX_VALUE)))
                 .addContainerGap())
         );
-        jPanel1Layout.setVerticalGroup(
-            jPanel1Layout.createParallelGroup(Alignment.LEADING)
+        jPanel1Layout.setVerticalGroup(jPanel1Layout.createParallelGroup(Alignment.LEADING)
             .addGroup(Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
                 .addGroup(jPanel1Layout.createParallelGroup(Alignment.BASELINE)
                     .addComponent(RadioOneRowPerFile)
                     .addComponent(RadioOneRowPerIdentification))
                 .addPreferredGap(ComponentPlacement.RELATED, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(jPanel1Layout.createParallelGroup(Alignment.BASELINE)
-                    .addComponent(cancelButton, GroupLayout.PREFERRED_SIZE, 23, GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cancelButton)
                     .addComponent(exportButton)
                     .addComponent(cmdEncoding, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
                     .addComponent(jLabel1))
@@ -313,8 +311,7 @@ public class ExportDialog extends JDialog {
 
         GroupLayout layout = new GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addComponent(jPanel1, Alignment.TRAILING, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
@@ -323,8 +320,7 @@ public class ExportDialog extends JDialog {
                     .addComponent(profileSelectLabel))
                 .addContainerGap())
         );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setVerticalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(profileSelectLabel)

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.java
@@ -270,7 +270,6 @@ public class ExportDialog extends JDialog {
         RadioOneRowPerIdentification.setToolTipText(NbBundle.getMessage(ExportDialog.class, "ExportDialog.RadioOneRowPerIdentification.toolTipText")); // NOI18N
 
         cmdEncoding.setModel(getOutputEncodings());
-        cmdEncoding.setEditor(null);
 
         jLabel1.setText(NbBundle.getMessage(ExportDialog.class, "ExportDialog.jLabel1.text_1")); // NOI18N
 
@@ -475,7 +474,7 @@ public class ExportDialog extends JDialog {
         private ProfileWrapper profile;
         
         /**
-         * @param checkBox
+         * Constructor
          */
         public CheckBoxEditor() {
             super(new JCheckBox());

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportProgressDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportProgressDialog.java
@@ -129,9 +129,10 @@ public class ExportProgressDialog extends JDialog {
                 .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
-
     private void cancelButtonActionPerformed(ActionEvent evt) {//GEN-FIRST:event_cancelButtonActionPerformed
         action.cancel();
+        setVisible(false);
+        dispose();
     }//GEN-LAST:event_cancelButtonActionPerformed
 
 


### PR DESCRIPTION
# Issue 
fix: a couple of issues on export dialog: 
- was impossible to close it cancel
- sometimes progress bar would get stuck on screen on small exports while it should be closed automatically
- Cancel button was trimmed vertically

fix https://github.com/digital-preservation/droid/issues/386

# Acceptance tests
run multiple exports with utf8 and utf8 with bom, check that it works without throwing exception nor showing a progress screen that cannot be closed.
 