### PR TITLE
Profile properties

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -34,6 +34,7 @@ package uk.gov.nationalarchives.droid.command.action;
 import java.io.PrintWriter;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.StringUtils;
 
 import uk.gov.nationalarchives.droid.command.FilterFieldCommand;
@@ -174,33 +175,21 @@ public class CommandFactoryImpl implements CommandFactory {
         return cmd;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public FilterFieldCommand getFilterFieldCommand() {
         return new FilterFieldCommand(printWriter);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getHelpCommand() {
         return new HelpCommand(printWriter);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getVersionCommand() {
         return new VersionCommand(printWriter);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getProfileCommand(final CommandLine cli) throws CommandLineSyntaxException {
         final String[] resources = cli.getOptionValues(CommandLineParam.RUN_PROFILE.toString());
@@ -216,15 +205,15 @@ public class CommandFactoryImpl implements CommandFactory {
         final ProfileRunCommand command = context.getProfileRunCommand();
         command.setDestination(destination[0]);
         command.setResources(resources);
-
         command.setRecursive(cli.hasOption(CommandLineParam.RECURSIVE.toString()));
 
+        final String[] propertyOverrides = cli.getOptionValues(CommandLineParam.PROFILE_PROPERTY.toString());
+        if (propertyOverrides != null && propertyOverrides.length > 0) {
+            command.setProperties(createProperties(propertyOverrides));
+        }
         return command;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getNoProfileCommand(final CommandLine cli) throws CommandLineSyntaxException {
         final String[] resources = cli.getOptionValues(CommandLineParam.RUN_NO_PROFILE.toString());
@@ -255,9 +244,6 @@ public class CommandFactoryImpl implements CommandFactory {
         return command;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getCheckSignatureUpdateCommand() {
         final CheckSignatureUpdateCommand command = context.getCheckSignatureUpdateCommand();
@@ -265,9 +251,6 @@ public class CommandFactoryImpl implements CommandFactory {
         return command;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getDownloadSignatureUpdateCommand() {
         final DownloadSignatureUpdateCommand command = context.getDownloadSignatureUpdateCommand();
@@ -275,9 +258,6 @@ public class CommandFactoryImpl implements CommandFactory {
         return command;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getDisplayDefaultSignatureVersionCommand() {
         final DisplayDefaultSignatureFileVersionCommand command = 
@@ -305,9 +285,6 @@ public class CommandFactoryImpl implements CommandFactory {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getListAllSignatureVersionsCommand() {
         final ListAllSignatureFilesCommand command = context.getListAllSignatureFilesCommand();
@@ -315,13 +292,27 @@ public class CommandFactoryImpl implements CommandFactory {
         return command;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public DroidCommand getListReportCommand() {
         final ListReportsCommand command = context.getListReportsCommand();
         command.setPrintWriter(printWriter);
         return command;
+    }
+
+    private PropertiesConfiguration createProperties(String[] properties) {
+        PropertiesConfiguration result = new PropertiesConfiguration();
+        for (String property : properties) {
+            addProperty(property, result);
+        }
+        return result;
+    }
+
+    private void addProperty(String property, PropertiesConfiguration properties) {
+        final int separator = property.indexOf('=');
+        if (separator > 0) {
+            String key = property.substring(0, separator);
+            String value = property.substring(separator + 1);
+            properties.addProperty(key, value);
+        }
     }
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
@@ -90,6 +90,16 @@ public enum CommandLineParam {
         }
     },
 
+    /**
+     * List of properties to override global default properties (e.g. max bytes to scan).
+     */
+    PROFILE_PROPERTY("Pr", "profile-property", true, -1, I18N.PROFILE_PROPERTY_HELP, "profile property") {
+        @Override
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) throws CommandLineException {
+            return null;
+        }
+    },
+
     /** Narrow filter. */
     ALL_FILTER("f", "filter-all", true, -1, I18N.ALL_FILTER, filters()) {
         @Override
@@ -403,6 +413,7 @@ public enum CommandLineParam {
         }
 
         options.addOption(PROFILES.newOption());
+        options.addOption(PROFILE_PROPERTY.newOption());
         options.addOption(REPORT_NAME.newOption());
         options.addOption(REPORT_OUTPUT_TYPE.newOption());
         options.addOption(SIGNATURE_FILE.newOption());

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
@@ -100,6 +100,16 @@ public enum CommandLineParam {
         }
     },
 
+    /**
+     * Specifies a property file to use to override any global defaults.
+     */
+    PROPERTY_FILE("Pf", "property-file", true, 1, I18N.PROPERTY_FILE_HELP, "property file") {
+        @Override
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) throws CommandLineException {
+            return null;
+        }
+    },
+
     /** Narrow filter. */
     ALL_FILTER("f", "filter-all", true, -1, I18N.ALL_FILTER, filters()) {
         @Override
@@ -414,6 +424,7 @@ public enum CommandLineParam {
 
         options.addOption(PROFILES.newOption());
         options.addOption(PROFILE_PROPERTY.newOption());
+        options.addOption(PROPERTY_FILE.newOption());
         options.addOption(REPORT_NAME.newOption());
         options.addOption(REPORT_OUTPUT_TYPE.newOption());
         options.addOption(SIGNATURE_FILE.newOption());

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ProfileRunCommand.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.apache.commons.configuration.PropertiesConfiguration;
+
 import uk.gov.nationalarchives.droid.core.interfaces.signature.SignatureFileException;
 import uk.gov.nationalarchives.droid.core.interfaces.signature.SignatureFileInfo;
 import uk.gov.nationalarchives.droid.core.interfaces.signature.SignatureManager;
@@ -63,6 +65,7 @@ public class ProfileRunCommand implements DroidCommand {
     private SignatureManager signatureManager;
     private LocationResolver locationResolver;
 
+    private PropertiesConfiguration propertyOverrides;
     /**
      * {@inheritDoc}
      */
@@ -70,7 +73,7 @@ public class ProfileRunCommand implements DroidCommand {
     public void execute() throws CommandExecutionException {
         try {
             Map<SignatureType, SignatureFileInfo> sigs = signatureManager.getDefaultSignatures();
-            ProfileInstance profile = profileManager.createProfile(sigs);
+            ProfileInstance profile = profileManager.createProfile(sigs, propertyOverrides);
             profile.changeState(ProfileState.VIRGIN);
 
             for (String resource : resources) {
@@ -144,5 +147,12 @@ public class ProfileRunCommand implements DroidCommand {
      */
     public void setLocationResolver(LocationResolver locationResolver) {
         this.locationResolver = locationResolver;
+    }
+
+    /**
+     * @param properties properties which should be used to override global default profile properties.
+     */
+    public void setProperties(PropertiesConfiguration properties) {
+        this.propertyOverrides = properties;
     }
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
@@ -62,7 +62,12 @@ public final class I18N {
      * Override default properties from the command line.
      */
     public static final String PROFILE_PROPERTY_HELP = "profile.property.help";
-    
+
+    /**
+     * Specify a property file to override global properties.
+     */
+    public static final String PROPERTY_FILE_HELP = "property.file.help";
+
     /** Report description. */
     public static final String REPORT_HELP = "report.help";
 

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
@@ -55,9 +55,14 @@ public final class I18N {
     /** Export description. */
     public static final String EXPORT_FORMAT_HELP = "export.format.help";
     
-    
     /** Profiles description. */
     public static final String PROFILES_HELP = "profiles.help";
+
+    /**
+     * Override default properties from the command line.
+     */
+    public static final String PROFILE_PROPERTY_HELP = "profile.property.help";
+    
     /** Report description. */
     public static final String REPORT_HELP = "report.help";
 

--- a/droid-command-line/src/main/resources/options.properties
+++ b/droid-command-line/src/main/resources/options.properties
@@ -42,7 +42,6 @@ The file paths of the profiles should be bounded by double quotes, and separated
 When used in conjunction with the -a option, the results of the new profile will be saved to that file, and you can only specify a single file.  \
 \n For example: droid -p "C:\\Results\\result1.droid" "C:\\Results\\result2.droid" -e "C:\\Exports\combinedResults.csv" \n \
 droid -a "C:\\Files\\A Folder" "C:\\Files\\file.xxx" -p "C:\\Results\\result1.droid"
-all.filter.help=[optional] Filter the profiles specified using the -p option.  Only results which match ALL filter criteria specified will appear.  Filter criteria are specified using the following method: <field><operator><values> where <field> is the name of a filterable field, <operator> is the type of comparison to use, and <values> are the value or values against which the field value should be compared.  The -k option provides information on the available fields and operators.  You can specify more than one filter criteria, bounded by double quotes and separated by spaces from each other.  For example: \
 profile.property.help=Each argument overrides a default profile property.  For example, to override the max bytes to scan parameter,\n  \
 droid -Pr "profile.maxBytesToScan=32768" -a "C:\\Files\\A Folder" -p "C:\\Results\\result1.droid".\n \
 Properties which can be overridden are those prefixed by "profile" in the droid.properties file contained in the droid home folder, \
@@ -63,8 +62,10 @@ profile.maxBytesToScan = 65536 \n \
 profile.matchAllExtensions = false \n \
 profile.generateHash = false \n \
 profile.hashAlgorithm = md5 \n 
+property.file.help=Specify a filename for a droid property file to override global default properties.
 report.help=Save the report generated to the file specified.  For example:\n  droid -p "C:\\Results\\result1.droid" -n "Comprehensive breakdown" -r "C:\\Reports\\result1Report.xml"
 report.name.help=Run the predefined report with the specified name on any profiles opened using the -p option. Available reports are in "%USERPROFILE%\.droid6\report_definitions", or listed in the GUI  For example:\n droid -p "C:\Results\\result1.droid" -n "Comprehensive breakdown" -r "C:\\Reports\\result1Report.xml"
+all.filter.help=[optional] Filter the profiles specified using the -p option.  Only results which match ALL filter criteria specified will appear.  Filter criteria are specified using the following method: <field><operator><values> where <field> is the name of a filterable field, <operator> is the type of comparison to use, and <values> are the value or values against which the field value should be compared.  The -k option provides information on the available fields and operators.  You can specify more than one filter criteria, bounded by double quotes and separated by spaces from each other.  For example: \
      \n droid -p "C:\\Results\\result3.droid" \n -f "PUID any_of fmt/111 fmt/112" \n -e "C:\\Exports\\filteredResults.csv"\
      \n droid -p "C:\\Results\\result1.droid" \n "C:\\Results\\result2.droid" \n -f "file_size > 0" \n -e "C:\\Exports\\filteredResults.csv"
 any.filter.help=[optional] Filter profiles as the -f option does, except results which match ANY of the specified filter criteria will appear.

--- a/droid-command-line/src/main/resources/options.properties
+++ b/droid-command-line/src/main/resources/options.properties
@@ -40,11 +40,31 @@ export.format.help=Export profiles to a CSV file with one row per profiled file/
 profiles.help=When used in conjunction with reporting, filtering or exporting, -p specifies a list of profiles to open.  \
 The file paths of the profiles should be bounded by double quotes, and separated by spaces from each other.  \
 When used in conjunction with the -a option, the results of the new profile will be saved to that file, and you can only specify a single file.  \
-\n For example: droid -p "C:\\Results\\result1.droid" "C:\\Results\\result2.droid" -e "C:\\Exports\combinedResults.csv" \n\
+\n For example: droid -p "C:\\Results\\result1.droid" "C:\\Results\\result2.droid" -e "C:\\Exports\combinedResults.csv" \n \
 droid -a "C:\\Files\\A Folder" "C:\\Files\\file.xxx" -p "C:\\Results\\result1.droid"
+all.filter.help=[optional] Filter the profiles specified using the -p option.  Only results which match ALL filter criteria specified will appear.  Filter criteria are specified using the following method: <field><operator><values> where <field> is the name of a filterable field, <operator> is the type of comparison to use, and <values> are the value or values against which the field value should be compared.  The -k option provides information on the available fields and operators.  You can specify more than one filter criteria, bounded by double quotes and separated by spaces from each other.  For example: \
+profile.property.help=Each argument overrides a default profile property.  For example, to override the max bytes to scan parameter,\n  \
+droid -Pr "profile.maxBytesToScan=32768" -a "C:\\Files\\A Folder" -p "C:\\Results\\result1.droid".\n \
+Properties which can be overridden are those prefixed by "profile" in the droid.properties file contained in the droid home folder, \
+ normally found in the .droid6 home folder under the user's home folder. These currently include the following properties:\n \
+profile.defaultThrottle = 0 \n \
+profile.defaultBinarySigFileVersion = DROID_SignatureFile_V96 \n \
+profile.defaultContainerSigFileVersion = container-signature-20200121 \n \
+profile.processTar = true \n \
+profile.processZip = true \n \
+profile.processGzip = true \n \
+profile.processRar = true \n \
+profile.process7zip = true \n \
+profile.processIso = true \n \
+profile.processBzip2 = true \n \
+profile.processArc = true \n \
+profile.processWarc = true \n \
+profile.maxBytesToScan = 65536 \n \
+profile.matchAllExtensions = false \n \
+profile.generateHash = false \n \
+profile.hashAlgorithm = md5 \n 
 report.help=Save the report generated to the file specified.  For example:\n  droid -p "C:\\Results\\result1.droid" -n "Comprehensive breakdown" -r "C:\\Reports\\result1Report.xml"
 report.name.help=Run the predefined report with the specified name on any profiles opened using the -p option. Available reports are in "%USERPROFILE%\.droid6\report_definitions", or listed in the GUI  For example:\n droid -p "C:\Results\\result1.droid" -n "Comprehensive breakdown" -r "C:\\Reports\\result1Report.xml"
-all.filter.help=[optional] Filter the profiles specified using the -p option.  Only results which match ALL filter criteria specified will appear.  Filter criteria are specified using the following method: <field><operator><values> where <field> is the name of a filterable field, <operator> is the type of comparison to use, and <values> are the value or values against which the field value should be compared.  The -k option provides information on the available fields and operators.  You can specify more than one filter criteria, bounded by double quotes and separated by spaces from each other.  For example: \
      \n droid -p "C:\\Results\\result3.droid" \n -f "PUID any_of fmt/111 fmt/112" \n -e "C:\\Exports\\filteredResults.csv"\
      \n droid -p "C:\\Results\\result1.droid" \n "C:\\Results\\result2.droid" \n -f "file_size > 0" \n -e "C:\\Exports\\filteredResults.csv"
 any.filter.help=[optional] Filter profiles as the -f option does, except results which match ANY of the specified filter criteria will appear.

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ProfileRunCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ProfileRunCommandTest.java
@@ -93,7 +93,7 @@ public class ProfileRunCommandTest {
         
         ProfileInstance profileInstance = mock(ProfileInstance.class);
         when(profileInstance.getUuid()).thenReturn("abcde");
-        when(profileManager.createProfile(sigs)).thenReturn(profileInstance);
+        when(profileManager.createProfile(sigs, null)).thenReturn(profileInstance);
         
         Future future = mock(Future.class);
         when(profileManager.start("abcde")).thenReturn(future);
@@ -108,7 +108,7 @@ public class ProfileRunCommandTest {
         
         verify(profileInstance).addResource(resource1);
         verify(profileInstance).addResource(resource2);
-        verify(profileManager).createProfile(sigs);
+        verify(profileManager).createProfile(sigs, null);
         verify(profileManager).start("abcde");
         verify(future).get();
         verify(profileManager).save(eq("abcde"), eq(Paths.get("test")), any(ProgressObserver.class));

--- a/droid-help/src/main/resources/Web pages/Command line control.html
+++ b/droid-help/src/main/resources/Web pages/Command line control.html
@@ -188,6 +188,57 @@
     <p>
        &nbsp;
     </p>
+
+    <h3>
+      -Pr,--profile-property &lt;properties...&gt;
+    </h3>
+    <p>
+      Specifies profile properties which should override any global defaults.  For example, to set the
+      max bytes to scan property of a profile when creating it:
+    </p>
+    <table cellpadding="8" bgcolor="#000000" border="0" cellspacing="0" width="100%">
+      <tr>
+        <td width="100%">
+          <font style=" background-color: #000000;" size="3" color="#ffffff" face=
+                  "Monospaced, Courier New, Courier, mono">&nbsp;droid –a “C:\Files\A Folder”
+            “C:\Files\file.xxx” –p “C:\Results\result1.droid” -Pr "profile.maxBytesToScan=4096"</font>
+        </td>
+      </tr>
+    </table>
+    <p>
+      Properties defined on the command line will override properties specified by any other source.
+      The profile properties which can be set are defined in the droid.properties file.
+      This resides in the droid home folder, which is normally located under the user's home folder in the .droid6 folder.
+    </p>
+    <p>
+      &nbsp;
+    </p>
+
+    <h3>
+      -Pf,--property-file <property file name>
+    </h3>
+    <p>
+      Specifies a file containing properties to override properties contained in the global default droid properties.
+    </p>
+    <table cellpadding="8" bgcolor="#000000" border="0" cellspacing="0" width="100%">
+      <tr>
+        <td width="100%">
+          <font style=" background-color: #000000;" size="3" color="#ffffff" face=
+                  "Monospaced, Courier New, Courier, mono">&nbsp;droid –a “C:\Files\A Folder”
+            “C:\Files\file.xxx” –p “C:\Results\result1.droid” -Pf "C:\Config\my.properties"</font>
+        </td>
+      </tr>
+    </table>
+    <p>
+      Properties defined in a file will override properties defined in the droid global default property file,
+      but can be overridden by properties specified directly on the command line with the -Pr option.
+      The profile properties which can be set are defined in the droid.properties file.
+      This resides in the droid home folder, which is normally located under the user's home folder in the .droid6 folder.
+    </p>
+    <p>
+      &nbsp;
+    </p>
+
     <h3>
        &nbsp;-p,--profile &lt;filename ...&gt;
     </h3>

--- a/droid-help/src/main/resources/Web pages/Command line control.html
+++ b/droid-help/src/main/resources/Web pages/Command line control.html
@@ -201,7 +201,7 @@
         <td width="100%">
           <font style=" background-color: #000000;" size="3" color="#ffffff" face=
                   "Monospaced, Courier New, Courier, mono">&nbsp;droid –a “C:\Files\A Folder”
-            “C:\Files\file.xxx” –p “C:\Results\result1.droid” -Pr "profile.maxBytesToScan=4096"</font>
+            “C:\Files\file.xxx” –p “C:\Results\result1.droid” -Pr "profile.maxBytesToScan=4096" "profile.processZip=false"</font>
         </td>
       </tr>
     </table>
@@ -215,7 +215,7 @@
     </p>
 
     <h3>
-      -Pf,--property-file <property file name>
+      -Pf,--property-file &lt;filename&gt;
     </h3>
     <p>
       Specifies a file containing properties to override properties contained in the global default droid properties.

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileContextLocator.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileContextLocator.java
@@ -38,8 +38,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.collections4.Transformer;
-import org.apache.commons.collections4.map.LazyMap;
+import org.apache.commons.configuration.CombinedConfiguration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.tree.OverrideCombiner;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,9 +71,7 @@ public class ProfileContextLocator {
     
     private enum TemplateStatus { NO_TEMPLATE, BLANK_TEMPLATE, SIGNATURE_TEMPLATE };
 
-    @SuppressWarnings("unchecked")
-    private Map<String, ProfileInstance> profileInstances = 
-        LazyMap.lazyMap(new HashMap<String, ProfileInstance>(), new ProfileTransformer());
+    private Map<String, ProfileInstance> profileInstances = new HashMap<>();
     
     private ProfileInstanceLocator profileInstanceLocator;
 
@@ -91,43 +90,6 @@ public class ProfileContextLocator {
         setGlobalConfig(config);
         setProfileInstanceLocator(instanceLocator);
     }
-
-    /**
-     * Transformer for creating profile instance objects.
-     * @author rflitcroft
-     */
-    private final class ProfileTransformer implements Transformer {
-        @Override
-        public Object transform(Object id) {
-            ProfileInstance profileInstance = new ProfileInstance(ProfileState.INITIALISING);
-            profileInstance.setUuid((String) id);
-            profileInstance.setThrottle(globalConfig.getProperties()
-                    .getInt(DroidGlobalProperty.DEFAULT_THROTTLE.getName()));
-            profileInstance.setHashAlgorithm(globalConfig.getProperties()
-                    .getString(DroidGlobalProperty.HASH_ALGORITHM.getName()));
-            profileInstance.setGenerateHash(globalConfig.getProperties()
-                    .getBoolean(DroidGlobalProperty.GENERATE_HASH.getName()));
-
-            profileInstance.setProcessTarFiles(globalConfig.getProperties()
-                    .getBoolean(DroidGlobalProperty.PROCESS_TAR.getName()));
-            profileInstance.setProcessZipFiles(globalConfig.getProperties()
-                    .getBoolean(DroidGlobalProperty.PROCESS_ZIP.getName()));
-            profileInstance.setProcessGzipFiles(globalConfig.getProperties().getBoolean(DroidGlobalProperty.PROCESS_GZIP.getName()));
-            profileInstance.setProcessRarFiles(globalConfig.getProperties().getBoolean(DroidGlobalProperty.PROCESS_RAR.getName()));
-            profileInstance.setProcess7zipFiles(globalConfig.getProperties().getBoolean(DroidGlobalProperty.PROCESS_7ZIP.getName()));
-            profileInstance.setProcessIsoFiles(globalConfig.getProperties().getBoolean(DroidGlobalProperty.PROCESS_ISO.getName()));
-            profileInstance.setProcessBzip2Files(globalConfig.getProperties().getBoolean(DroidGlobalProperty.PROCESS_BZIP2.getName()));
-
-            profileInstance.setProcessArcFiles(globalConfig.getProperties().getBoolean(DroidGlobalProperty.PROCESS_ARC.getName()));
-            profileInstance.setProcessWarcFiles(globalConfig.getProperties().getBoolean(DroidGlobalProperty.PROCESS_WARC.getName()));
-
-            profileInstance.setMaxBytesToScan(globalConfig.getProperties()
-                    .getLong(DroidGlobalProperty.MAX_BYTES_TO_SCAN.getName()));
-            profileInstance.setMatchAllExtensions(globalConfig.getProperties()
-                    .getBoolean(DroidGlobalProperty.EXTENSION_ALL.getName()));
-            return profileInstance;
-        }
-    }
     
     /**
      * Lazily instantiates (if necessary) and returns the profile instance with the name given.
@@ -135,9 +97,24 @@ public class ProfileContextLocator {
      * @return the profile instance with the name given
      */
     public ProfileInstance getProfileInstance(String id) {
-        return profileInstances.get(id);
+        return getProfileInstance(id, null);
     }
-    
+
+    /**
+     * Lazily instantiates (if necessary) and returns the profile instance with the name given.
+     * @param id the id of the profile instance
+     * @param propertiesOverride properties to override global profile defaults.
+     * @return the profile instance with the name given
+     */
+    public ProfileInstance getProfileInstance(String id, PropertiesConfiguration propertiesOverride) {
+        ProfileInstance result = profileInstances.get(id);
+        if (result == null) {
+            result = createNewProfileInstance(id, propertiesOverride);
+        }
+        return result;
+    }
+
+
     /**
      * Adds a profile context.
      * @param profileInstance the profile instance to add
@@ -410,5 +387,41 @@ public class ProfileContextLocator {
     public void setGlobalConfig(DroidGlobalConfig globalConfig) {
         this.globalConfig = globalConfig;
     }
-    
+
+    private ProfileInstance createNewProfileInstance(String id, PropertiesConfiguration propertiesOverride) {
+        PropertiesConfiguration mergedConfig = mergeConfigurations(globalConfig.getProperties(), propertiesOverride);
+        ProfileInstance profileInstance = new ProfileInstance(ProfileState.INITIALISING);
+        profileInstance.setUuid(id);
+        profileInstance.setThrottle(mergedConfig.getInt(DroidGlobalProperty.DEFAULT_THROTTLE.getName()));
+        profileInstance.setHashAlgorithm(mergedConfig.getString(DroidGlobalProperty.HASH_ALGORITHM.getName()));
+        profileInstance.setGenerateHash(mergedConfig.getBoolean(DroidGlobalProperty.GENERATE_HASH.getName()));
+        profileInstance.setProcessTarFiles(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_TAR.getName()));
+        profileInstance.setProcessZipFiles(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_ZIP.getName()));
+        profileInstance.setProcessGzipFiles(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_GZIP.getName()));
+        profileInstance.setProcessRarFiles(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_RAR.getName()));
+        profileInstance.setProcess7zipFiles(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_7ZIP.getName()));
+        profileInstance.setProcessIsoFiles(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_ISO.getName()));
+        profileInstance.setProcessBzip2Files(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_BZIP2.getName()));
+        profileInstance.setProcessArcFiles(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_ARC.getName()));
+        profileInstance.setProcessWarcFiles(mergedConfig.getBoolean(DroidGlobalProperty.PROCESS_WARC.getName()));
+        profileInstance.setMaxBytesToScan(mergedConfig.getLong(DroidGlobalProperty.MAX_BYTES_TO_SCAN.getName()));
+        profileInstance.setMatchAllExtensions(mergedConfig.getBoolean(DroidGlobalProperty.EXTENSION_ALL.getName()));
+        addProfileContext(profileInstance);
+        return profileInstance;
+    }
+
+    private PropertiesConfiguration mergeConfigurations(PropertiesConfiguration defaults, PropertiesConfiguration overrides) {
+        if (overrides != null) {
+            CombinedConfiguration combined = new CombinedConfiguration();
+            combined.setNodeCombiner(new OverrideCombiner());
+            combined.addConfiguration(overrides); // override properties first.
+            combined.addConfiguration(defaults);
+            PropertiesConfiguration merged = new PropertiesConfiguration();
+            merged.append(combined);
+            return merged;
+        }
+        return defaults;
+    }
+
+
 }

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManager.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManager.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
+import org.apache.commons.configuration.PropertiesConfiguration;
+
 import uk.gov.nationalarchives.droid.core.interfaces.signature.SignatureFileInfo;
 import uk.gov.nationalarchives.droid.core.interfaces.signature.SignatureType;
 import uk.gov.nationalarchives.droid.profile.referencedata.Format;
@@ -55,18 +57,27 @@ public interface ProfileManager {
     /**
      * Creates a profile using the signature file specified.
      * 
-     * @param sigFiles
-     *            the signature files.
+     * @param sigFiles the signature files.
      * @return the new Profile Instance.
      * @throws ProfileManagerException if the profile could not be created
      */
     ProfileInstance createProfile(Map<SignatureType, SignatureFileInfo> sigFiles) throws ProfileManagerException;
 
     /**
+     * Creates a profile using the signature file specified with global property overrides.
+     *
+     * @param sigFiles the signature files.
+     * @param propertyOverrides properties to override default global properties when creating a profile.
+     * @return the new Profile Instance.
+     * @throws ProfileManagerException if the profile could not be created
+     */
+    ProfileInstance createProfile(Map<SignatureType, SignatureFileInfo> sigFiles,
+                                  PropertiesConfiguration propertyOverrides) throws ProfileManagerException;
+
+    /**
      * Loads the reference data for the selected profile.
      * 
-     * @param profileId
-     *            the profile to start
+     * @param profileId the profile to start
      * @return the new Profile Instance.
      */
     ReferenceData getReferenceData(String profileId);
@@ -74,8 +85,7 @@ public interface ProfileManager {
     /**
      * Starts a profile asynchronously.
      * 
-     * @param profileId
-     *            the profile to start
+     * @param profileId the profile to start
      * @return future wihich is done when the profile finishes.
      * @throws IOException if there was a problem with the profile. 
      */
@@ -84,24 +94,21 @@ public interface ProfileManager {
     /**
      * Stops a profile.
      * 
-     * @param profileId
-     *            the profile to stop
+     * @param profileId the profile to stop
      */
     void stop(String profileId);
 
     /**
      * Closes a profile and releases all resources.
      * 
-     * @param profileId
-     *            the profile to close
+     * @param profileId the profile to close
      */
     void closeProfile(String profileId);
 
     /**
      * Opens a profile.
      * 
-     * @param profileId
-     *            the profile to open
+     * @param profileId the profile to open
      * @return the profile.
      */
     ProfileInstance openProfile(String profileId);
@@ -109,8 +116,7 @@ public interface ProfileManager {
     /**
      * Updates the profile spec.
      * 
-     * @param profileId
-     *            the profile ID
+     * @param profileId the profile ID
      * @param profileSpec
      *            the updated spec
      */
@@ -119,26 +125,22 @@ public interface ProfileManager {
     /**
      * Sets the results observer for the profile given.
      * 
-     * @param profileUuid
-     *            the profile ID
+     * @param profileUuid the profile ID
      * @param observer
      *            the observer to set
      */
     void setResultsObserver(String profileUuid, ProfileResultObserver observer);
 
     /**
-     * @param profileUuid
-     *            the profile ID
-     * @param parentId
-     *            the ID of the parent of the node
+     * @param profileUuid the profile ID
+     * @param parentId the ID of the parent of the node
      * @return the profile resource node at the URL with its immediate children,
      */
     List<ProfileResourceNode> findProfileResourceNodeAndImmediateChildren(
             String profileUuid, Long parentId);
 
     /**
-     * @param profileUuid
-     *            the profile ID
+     * @param profileUuid the profile ID
      * @return All root nodes for the profile given
      */
     List<ProfileResourceNode> findRootNodes(String profileUuid);
@@ -146,10 +148,8 @@ public interface ProfileManager {
     /**
      * Sets the progress monitor for the specified profile.
      * 
-     * @param profileId
-     *            the profile ID
-     * @param observer
-     *            the progress observer to set.
+     * @param profileId the profile ID
+     * @param observer the progress observer to set.
      */
     void setProgressObserver(String profileId, ProgressObserver observer);
 
@@ -157,15 +157,11 @@ public interface ProfileManager {
      * Saves the specified profile to the file specified. The file will be
      * created if it does not already exist or overwritten if it exists.
      * 
-     * @param profileId
-     *            the ID of the profile.
-     * @param destination
-     *            the file to be created or overwitten
-     * @param progressCallback
-     *            a progress call back object
+     * @param profileId the ID of the profile.
+     * @param destination the file to be created or overwitten
+     * @param progressCallback a progress call back object
      * @return the saved profile instance
-     * @throws IOException
-     *             - if the file IO failed.
+     * @throws IOException - if the file IO failed.
      */
     ProfileInstance save(String profileId, Path destination,
             ProgressObserver progressCallback) throws IOException;
@@ -173,21 +169,17 @@ public interface ProfileManager {
     /**
      * Opens a profile from the file specified.
      * 
-     * @param source
-     *            the source file
-     * @param progressCallback
-     *            a progress call back object
+     * @param source the source file
+     * @param progressCallback a progress call back object
      * @return the profile's UUID
-     * @throws IOException
-     *             if the File could not be read.
+     * @throws IOException if the File could not be read.
      */
     ProfileInstance open(Path source, ProgressObserver progressCallback)
         throws IOException;
 
     /**
      * Retrieves all the formats.
-     * @param profileId Profile Id of the profile.
-     *        for which format is required.
+     * @param profileId Profile Id of the profile for which format is required.
      * @return list of formats
      */
     List<Format> getAllFormats(String profileId);

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImpl.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.zip.ZipFile;
 
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,16 +96,14 @@ public class ProfileManagerImpl implements ProfileManager {
         setConfig(config);
     }
 
-    /**
-     * Gets a profile instance manager.
-     * 
-     * @param sigFileInfos
-     *            the path to the signature file to be used for this profile.
-     * @return the profile instance created.
-     * @throws ProfileManagerException if the profile could not be created
-     */
     @Override
-    public ProfileInstance createProfile(Map<SignatureType, SignatureFileInfo> sigFileInfos) 
+    public ProfileInstance createProfile(Map<SignatureType, SignatureFileInfo> sigFileInfos) throws ProfileManagerException {
+        return createProfile(sigFileInfos, null);
+    }
+
+    @Override
+    public ProfileInstance createProfile(Map<SignatureType, SignatureFileInfo> sigFileInfos,
+                                         PropertiesConfiguration propertyOverrides)
         throws ProfileManagerException {
         Map<SignatureType, SignatureFileInfo> signatures = sigFileInfos;
         if (sigFileInfos == null) {
@@ -118,7 +117,7 @@ public class ProfileManagerImpl implements ProfileManager {
         
         String profileId = String.valueOf(System.currentTimeMillis());
         log.info("Creating profile: " + profileId);
-        ProfileInstance profile = profileContextLocator.getProfileInstance(profileId);
+        ProfileInstance profile = profileContextLocator.getProfileInstance(profileId, propertyOverrides);
         
         final Path profileHomeDir = config.getProfilesDir().resolve(profile.getUuid());
         FileUtil.mkdirsQuietly(profileHomeDir);
@@ -129,8 +128,6 @@ public class ProfileManagerImpl implements ProfileManager {
 
         profile.setUuid(profileId);
         profile.setProfileSpec(new ProfileSpec());
-
-        
 
         // Persist the profile.
         profileSpecDao.saveProfile(profile, profileHomeDir);

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImplTest.java
@@ -227,8 +227,7 @@ public class ProfileManagerImplTest {
     }
 
     @Test
-    public void testOverrideProperties() throws ProfileManagerException, ConfigurationException {
-
+    public void testOverrideProperties() throws ProfileManagerException, ConfigurationException, InterruptedException {
         globalConfig.init();
         ProfileContextLocator realContextLocator = new ProfileContextLocator();
         realContextLocator.setGlobalConfig(globalConfig);
@@ -237,24 +236,28 @@ public class ProfileManagerImplTest {
         ProfileInstance mainInstance = createProfile();
 
         // Test process zip flag:
+        Thread.sleep(10);
         Boolean propertyFlag = globalConfig.getProperties().getBoolean("profile.processZip");
         ProfileInstance overridden = createOverriddenProfile("profile.processZip", propertyFlag);
         assertEquals(propertyFlag, mainInstance.getProcessZipFiles());
         assertNotEquals(propertyFlag, overridden.getProcessZipFiles());
 
         // Test process tar flag:
+        Thread.sleep(10);
         propertyFlag = globalConfig.getProperties().getBoolean("profile.processTar");
         overridden = createOverriddenProfile("profile.processTar", propertyFlag);
         assertEquals(propertyFlag, mainInstance.getProcessTarFiles());
         assertNotEquals(propertyFlag, overridden.getProcessTarFiles());
 
         // Test match all extensions:
+        Thread.sleep(10);
         propertyFlag = globalConfig.getProperties().getBoolean("profile.matchAllExtensions");
         overridden = createOverriddenProfile("profile.matchAllExtensions", propertyFlag);
         assertEquals(propertyFlag, mainInstance.getMatchAllExtensions());
         assertNotEquals(propertyFlag, overridden.getMatchAllExtensions());
 
         // Test max bytes to scan:
+        Thread.sleep(10);
         Long maxBytes = globalConfig.getProperties().getLong("profile.maxBytesToScan");
         overridden = createOverriddenProfile("profile.maxBytesToScan", maxBytes);
         assertEquals(maxBytes, mainInstance.getMaxBytesToScan());

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImplTest.java
@@ -42,14 +42,15 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -94,15 +95,16 @@ public class ProfileManagerImplTest {
     public void setup() throws IOException {
         ProfileUuidGenerator uuidGenerator = mock(ProfileUuidGenerator.class);
         when(uuidGenerator.generateUuid()).thenReturn("abc");
-        
+        globalConfig = new DroidGlobalConfig();
+
         profileManager = new ProfileManagerImpl();
 //        profileManager.setUuidGenerator(uuidGenerator);
         profileSpecDao = mock(ProfileSpecDao.class);
         profileContextLocator = mock(ProfileContextLocator.class);
         profileManager.setProfileSpecDao(profileSpecDao);
+        profileManager.setConfig(globalConfig);
         
         profileManager.setProfileContextLocator(profileContextLocator);
-        globalConfig = new DroidGlobalConfig();
         profileContextLocator.setGlobalConfig(globalConfig);
     }
     
@@ -222,5 +224,64 @@ public class ProfileManagerImplTest {
         profileManager.setThrottleValue(profileId, 12345);
         
         verify(profileInstanceManager).setThrottleValue(12345);
+    }
+
+    @Test
+    public void testOverrideProperties() throws ProfileManagerException, ConfigurationException {
+
+        globalConfig.init();
+        ProfileContextLocator realContextLocator = new ProfileContextLocator();
+        realContextLocator.setGlobalConfig(globalConfig);
+        profileManager.setProfileContextLocator(realContextLocator);
+
+        ProfileInstance mainInstance = createProfile();
+
+        // Test process zip flag:
+        Boolean propertyFlag = globalConfig.getProperties().getBoolean("profile.processZip");
+        ProfileInstance overridden = createOverriddenProfile("profile.processZip", propertyFlag);
+        assertEquals(propertyFlag, mainInstance.getProcessZipFiles());
+        assertNotEquals(propertyFlag, overridden.getProcessZipFiles());
+
+        // Test process tar flag:
+        propertyFlag = globalConfig.getProperties().getBoolean("profile.processTar");
+        overridden = createOverriddenProfile("profile.processTar", propertyFlag);
+        assertEquals(propertyFlag, mainInstance.getProcessTarFiles());
+        assertNotEquals(propertyFlag, overridden.getProcessTarFiles());
+
+        // Test match all extensions:
+        propertyFlag = globalConfig.getProperties().getBoolean("profile.matchAllExtensions");
+        overridden = createOverriddenProfile("profile.matchAllExtensions", propertyFlag);
+        assertEquals(propertyFlag, mainInstance.getMatchAllExtensions());
+        assertNotEquals(propertyFlag, overridden.getMatchAllExtensions());
+
+        // Test max bytes to scan:
+        Long maxBytes = globalConfig.getProperties().getLong("profile.maxBytesToScan");
+        overridden = createOverriddenProfile("profile.maxBytesToScan", maxBytes);
+        assertEquals(maxBytes, mainInstance.getMaxBytesToScan());
+        assertEquals((Long) (maxBytes + 1000L), (Long) overridden.getMaxBytesToScan());
+    }
+
+
+    private ProfileInstance createProfile() throws ProfileManagerException {
+        Map<SignatureType, SignatureFileInfo> sigInfo = new HashMap<>();
+        return profileManager.createProfile(sigInfo);
+    }
+
+    private ProfileInstance createOverriddenProfile(String propertyName, Boolean value) throws ProfileManagerException {
+        Map<SignatureType, SignatureFileInfo> sigInfo = new HashMap<>();
+        PropertiesConfiguration overrides = new PropertiesConfiguration();
+        if (value) {
+            overrides.setProperty(propertyName, "false");
+        } else {
+            overrides.setProperty(propertyName, "true");
+        }
+        return profileManager.createProfile(sigInfo, overrides);
+    }
+
+    private ProfileInstance createOverriddenProfile(String propertyName, Long value) throws ProfileManagerException {
+        Map<SignatureType, SignatureFileInfo> sigInfo = new HashMap<>();
+        PropertiesConfiguration overrides = new PropertiesConfiguration();
+        overrides.setProperty(propertyName, value + 1000);
+        return profileManager.createProfile(sigInfo, overrides);
     }
 }


### PR DESCRIPTION
Allows global default profile properties to be overridden when creating a new profile.  This allows us to set profile properties directly on the command line, or by specifying an alternate profile property override file to use, or both.

**Usage**
To override a default profile property such as max bytes to scan, you specify it with the **-Pr** option:

`droid -a "/home/user/Documents" -R -p "/home/user/docprofile.droid" -Pr "profile.maxBytesToScan=1024"`

You can set more than one property by just specifying each as additional arguments:

`droid -a "/home/user/Documents" -R -p "/home/user/docprofile.droid" -Pr "profile.maxBytesToScan=1024" "profile.processZip=false"`

If you have a lot of properties you want to override all the time, or different sets of properties you want to re-use, you can put them in a property file and tell DROID to use that with the **-Pf** option:

`droid -a "/home/user/Documents" -R -p "/home/user/docprofile.droid" -Pf "/home/user/my.properties"`

You can also specify properties on the command line with -Pr and use a property file with -Pf. In this case, any properties specified directly on the command line take precedence over the ones in the file (which in turn has precedence over properties defined in the droid global property file).

`droid -a "/home/user/Documents" -R -p "/home/user/docprofile.droid" -Pr "profile.maxBytesToScan=1024" "profile.processZip=false" -Pf "/home/user/my.properties"`

To see all the profile properties that can be set, look at the droid.properties file in the droid home folder. This is normally located in the .droid6 folder under the user's home folder.