### PR TITLE
fix: .bat script in jre bundle to enable running from network drive

### DIFF
--- a/droid-binary/bin/droid.bat
+++ b/droid-binary/bin/droid.bat
@@ -147,6 +147,6 @@ GOTO end
 
 :NOPARAM
 REM No command-line parameters passed -- run GUI version:
-start ${JRE_BIN_PATH}javaw %DROID_OPTIONS% -jar "%DROID_HOME%droid-ui-${project.version}.jar"
+start "" "${JRE_BIN_PATH}javaw" %DROID_OPTIONS% -jar "%DROID_HOME%droid-ui-${project.version}.jar"
 
 :END


### PR DESCRIPTION
# Context
Issue in bat script preventing the .bat file from running on Windows from network drive

fix https://github.com/digital-preservation/droid/issues/411

# Acceptance tests
run both bundle with jre and without jre from network drive on Windows
Ensure no exception is thrown (we just couldn't start the application before in the bundle case)

# Caveat
This should just NOT be done, @Dclipsham how can we invite strongly users to avoid running the jre from a network folder? 
As discussed on slack running the local jre to open a jar on the network is one thing (bad idea in my humble opinion as far as performances are concerned), but running the jre and the jar file both on the network is even worse!
I expect complaints in the future about the poor performances of Droid related to that usecase