### PR TITLE
Fix support for siard 2.1 issue418

### DIFF
--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignature.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignature.java
@@ -49,8 +49,6 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ContainerSignature {
 
-    private static final String FORWARD_SLASH = "/";
-
     @XmlAttribute(name = "Id")
     private int id;
     
@@ -90,30 +88,11 @@ public class ContainerSignature {
         if (this.filesMap == null) {
             Map<String, ContainerFile> containerFileMap = new HashMap<String, ContainerFile>();
             for (ContainerFile file : files) {
-                final String path = stripTrailingForwardSlash(file.getPath());
-                containerFileMap.put(path, file);
+                containerFileMap.put(file.getPath(), file);
             }
             this.filesMap = containerFileMap;
         }
         return this.filesMap;
-    }
-
-    /**
-     * Removes any trailing forward slash from a path.
-     * This ensures that paths are presented for matching in a standardised format,
-     * no matter how they are specified in the container signature file.
-     * The ContainerSignatureMatch object also strips trailing forward slashes before attempting
-     * a match, ensuring they are also matched no matter whether OLE2, ZIP or another container
-     * format uses trailing slashes or not.
-     *
-     * @param path The path to strip a trailing forward slash from, if it exists.
-     * @return The path without any trailing forward slash.
-     */
-    private String stripTrailingForwardSlash(String path) {
-        if (path != null && path.endsWith(FORWARD_SLASH)) {
-            return path.substring(0, path.length() - 1);
-        }
-        return path;
     }
 
     /**

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatch.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatch.java
@@ -45,8 +45,6 @@ import uk.gov.nationalarchives.droid.core.signature.droid6.InternalSignatureColl
  */
 public class ContainerSignatureMatch {
 
-    private static final String FORWARD_SLASH = "/";
-
     private ContainerSignature signature;
     private long maxBytesToScan = -1;
 
@@ -86,11 +84,10 @@ public class ContainerSignatureMatch {
      * @param entryName the name of the container file entry
      */
     public void matchFileEntry(String entryName) {
-        final String name = stripEndingForwardSlash(entryName);
-        if (unmatchedFiles.contains(name)) {
-            InternalSignatureCollection binSigs = signature.getFiles().get(name).getCompiledBinarySignatures();
+        if (unmatchedFiles.contains(entryName)) {
+            InternalSignatureCollection binSigs = signature.getFiles().get(entryName).getCompiledBinarySignatures();
             if (binSigs == null) {
-                unmatchedFiles.remove(name);
+                unmatchedFiles.remove(entryName);
             }
         }
     }
@@ -102,9 +99,8 @@ public class ContainerSignatureMatch {
      */
     public boolean needsBinaryMatch(String entryName) {
         boolean needsMatch = false;
-        final String name = stripEndingForwardSlash(entryName);
-        if (unmatchedFiles.contains(name)) {
-            InternalSignatureCollection binarySigs = signature.getFiles().get(name).getCompiledBinarySignatures();
+        if (unmatchedFiles.contains(entryName)) {
+            InternalSignatureCollection binarySigs = signature.getFiles().get(entryName).getCompiledBinarySignatures();
             needsMatch = binarySigs != null;
         }
         return needsMatch;
@@ -121,15 +117,14 @@ public class ContainerSignatureMatch {
      */
     public void matchBinaryContent(String entryName, ByteReader content) {
         boolean matched = true;
-        String name = stripEndingForwardSlash(entryName);
-        if (unmatchedFiles.contains(name)) {
+        if (unmatchedFiles.contains(entryName)) {
             Map<String, ContainerFile> sigFiles = signature.getFiles();
-            InternalSignatureCollection binSigs = sigFiles.get(name).getCompiledBinarySignatures();
+            InternalSignatureCollection binSigs = sigFiles.get(entryName).getCompiledBinarySignatures();
             if (binSigs != null) {
                 matched = binSigs.getMatchingSignatures(content, maxBytesToScan).size() > 0;
             }
             if (matched) {
-                unmatchedFiles.remove(name);
+                unmatchedFiles.remove(entryName);
             }
         }
     }
@@ -139,18 +134,6 @@ public class ContainerSignatureMatch {
      */
     public ContainerSignature getSignature() {
         return signature;
-    }
-
-    /**
-     * Removes a last forward slash on a path if it exists.
-     * @param path The path to strip.
-     * @return A path without an ending forward slash.
-     */
-    private String stripEndingForwardSlash(String path) {
-        if (path != null && path.endsWith(FORWARD_SLASH)) {
-            return path.substring(0, path.length() - 1);
-        }
-        return path;
     }
 
 }

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchTest.java
@@ -113,26 +113,25 @@ public class ContainerSignatureMatchTest {
         assertTrue(match.isMatch());
     }
 
-//    @Test
-//    public void shouldDelegateToBinarySignatureMatcherWhenBinarySignatureExists() {
-//        ByteReader mockBinaryContent = mock(ByteReader.class);
-//        ContainerFile containerFile = mock(ContainerFile.class);
-//
-//        Map<String, ContainerFile> files = new HashMap<String, ContainerFile>();
-//        files.put("header/siardversion/2.1/", containerFile);
-//
-//        ContainerSignature sig = mock(ContainerSignature.class);
-//        when(sig.getFiles()).thenReturn(files);
-//
-//        InternalSignatureCollection mockSignatures = mock(InternalSignatureCollection.class);
-//        when(containerFile.getCompiledBinarySignatures()).thenReturn(mockSignatures);
-//
-//        ContainerSignatureMatch match = new ContainerSignatureMatch(sig, -1L);
-//
-//        match.matchBinaryContent("header/siardversion/2.1/", mockBinaryContent);
-//        assertTrue(match.isMatch());
-//
-//        verify(mockSignatures, times(1)).getMatchingSignatures(mockBinaryContent, -1L);
-//    }
+    @Test
+    public void shouldDelegateToBinarySignatureMatcherWhenBinarySignatureExists() {
+        ByteReader mockBinaryContent = mock(ByteReader.class);
+        ContainerFile containerFile = mock(ContainerFile.class);
+
+        Map<String, ContainerFile> files = new HashMap<String, ContainerFile>();
+        files.put("header/siardversion/2.1/", containerFile);
+
+        ContainerSignature sig = mock(ContainerSignature.class);
+        when(sig.getFiles()).thenReturn(files);
+
+        InternalSignatureCollection mockSignatures = mock(InternalSignatureCollection.class);
+        when(containerFile.getCompiledBinarySignatures()).thenReturn(mockSignatures);
+
+        ContainerSignatureMatch match = new ContainerSignatureMatch(sig, -1L);
+
+        match.matchBinaryContent("header/siardversion/2.1/", mockBinaryContent);
+
+        verify(mockSignatures, times(1)).getMatchingSignatures(mockBinaryContent, -1L);
+    }
 
 }

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchTest.java
@@ -37,11 +37,12 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import uk.gov.nationalarchives.droid.core.signature.ByteReader;
+import uk.gov.nationalarchives.droid.core.signature.droid6.InternalSignatureCollection;
 
 /**
  * @author rflitcroft
@@ -96,81 +97,42 @@ public class ContainerSignatureMatchTest {
         assertTrue(match.isMatch());
     }
     
-    @Ignore
+
     @Test
-    public void testNeedsTextMatch() {
-        ContainerFile file1 = mock(ContainerFile.class);
-        //when(file1.getTextSignature()).thenReturn("sig");
-        when(file1.getPath()).thenReturn("entry1");
-        
-        ContainerFile file2 = mock(ContainerFile.class);
-        //when(file2.getTextSignature()).thenReturn(null);
-        when(file1.getPath()).thenReturn("entry2");
-        
+    public void shouldMatchBinaryContentByFileNameWithTheFullPathWhenNoBinaryContent() {
+        ByteReader binaryContent = null;
         Map<String, ContainerFile> files = new HashMap<String, ContainerFile>();
-        files.put("entry1", file1);
-        files.put("entry2", file2);
-        
+        files.put("header/siardversion/2.1/", new ContainerFile());
+
         ContainerSignature sig = mock(ContainerSignature.class);
         when(sig.getFiles()).thenReturn(files);
 
-        match = new ContainerSignatureMatch(sig, -1L);
-        
-        //assertTrue(match.needsTextMatch("entry1"));
-        //assertFalse(match.needsTextMatch("entry2"));
-    }
-    
-    @Ignore
-    @Test
-    public void testMatchTextContent() {
-        ContainerFile file1 = mock(ContainerFile.class);
-        //when(file1.getTextSignature()).thenReturn("sig");
-        when(file1.getPath()).thenReturn("entry1");
-        
-        ContainerFile file2 = mock(ContainerFile.class);
-        //when(file2.getTextSignature()).thenReturn(null);
-        when(file1.getPath()).thenReturn("entry2");
-        
-        Map<String, ContainerFile> files = new HashMap<String, ContainerFile>();
-        files.put("entry1", file1);
-        files.put("entry2", file2);
-        
-        ContainerSignature sig = mock(ContainerSignature.class);
-        when(sig.getFiles()).thenReturn(files);
+        ContainerSignatureMatch match = new ContainerSignatureMatch(sig, -1L);
 
-        match = new ContainerSignatureMatch(sig, -1L);
-        
-        //match.matchTextContent("entry1", "fig");
-        //assertFalse(match.isMatch());
-
-        match.matchFileEntry("entry2");
-        assertFalse(match.isMatch());
-
-        //match.matchTextContent("entry1", "sig");
-        //assertTrue(match.isMatch());
-        
+        match.matchBinaryContent("header/siardversion/2.1/", binaryContent);
+        assertTrue(match.isMatch());
     }
 
-    @Ignore
-    @Test(expected = NullPointerException.class)
-    public void testMatchTextContentWithFileWithoutTextSignature() {
-        ContainerFile file1 = mock(ContainerFile.class);
-        //when(file1.getTextSignature()).thenReturn("sig");
-        when(file1.getPath()).thenReturn("entry1");
-        
-        ContainerFile file2 = mock(ContainerFile.class);
-        //when(file2.getTextSignature()).thenReturn(null);
-        when(file1.getPath()).thenReturn("entry2");
-        
-        Map<String, ContainerFile> files = new HashMap<String, ContainerFile>();
-        files.put("entry1", file1);
-        files.put("entry2", file2);
-        
-        ContainerSignature sig = mock(ContainerSignature.class);
-        when(sig.getFiles()).thenReturn(files);
+//    @Test
+//    public void shouldDelegateToBinarySignatureMatcherWhenBinarySignatureExists() {
+//        ByteReader mockBinaryContent = mock(ByteReader.class);
+//        ContainerFile containerFile = mock(ContainerFile.class);
+//
+//        Map<String, ContainerFile> files = new HashMap<String, ContainerFile>();
+//        files.put("header/siardversion/2.1/", containerFile);
+//
+//        ContainerSignature sig = mock(ContainerSignature.class);
+//        when(sig.getFiles()).thenReturn(files);
+//
+//        InternalSignatureCollection mockSignatures = mock(InternalSignatureCollection.class);
+//        when(containerFile.getCompiledBinarySignatures()).thenReturn(mockSignatures);
+//
+//        ContainerSignatureMatch match = new ContainerSignatureMatch(sig, -1L);
+//
+//        match.matchBinaryContent("header/siardversion/2.1/", mockBinaryContent);
+//        assertTrue(match.isMatch());
+//
+//        verify(mockSignatures, times(1)).getMatchingSignatures(mockBinaryContent, -1L);
+//    }
 
-        match = new ContainerSignatureMatch(sig, -1L);
-        
-        //match.matchTextContent("entry2", "sig");
-    }
 }


### PR DESCRIPTION
It looks like we were generating various maps in the codebase for identifying signature entries and comparisons, however when we created the keys in map, we were stripping the trailing slash. When truezip reads a file, the zip entries for siard contains the trailing slash, so our matching mechanism fails. 

Going through the signature files, siard 2.1 is the only path that had a trailing slash so the change won't affect other files. 

[Update Jeremie] fix https://github.com/digital-preservation/droid/issues/418