### PR TITLE
Filter by extension should work when recursing folders

### DIFF
--- a/droid-command-line/pom.xml
+++ b/droid-command-line/pom.xml
@@ -265,5 +265,10 @@
             <artifactId>fat32-lib</artifactId>
             <version>0.6.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/NoProfileRunCommand.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 
 import uk.gov.nationalarchives.droid.command.ResultPrinter;
 import uk.gov.nationalarchives.droid.command.archive.ArchiveConfiguration;
+import uk.gov.nationalarchives.droid.command.filter.Creator.DirectoryStreamFilterCreator;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureDefinitions;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureSaxParser;
 import uk.gov.nationalarchives.droid.core.BinarySignatureIdentifier;
@@ -114,7 +115,7 @@ public class NoProfileRunCommand implements DroidCommand {
        //BNO - allow processing of a single file as well as directory
         final Collection<Path> matchedFiles;
         if (Files.isDirectory(targetDirectoryOrFile)) {
-            final DirectoryStream.Filter<Path> filter = createFilter();
+            final DirectoryStream.Filter<Path> filter = new DirectoryStreamFilterCreator(recursive, extensions).create();
             try {
                 matchedFiles = FileUtil.listFiles(targetDirectoryOrFile, this.recursive, filter);
             } catch (final IOException e) {
@@ -322,41 +323,4 @@ public class NoProfileRunCommand implements DroidCommand {
         this.expandArchiveTypes = expandArchiveTypes;
     }
 
-    /**
-     * Create an appropriate filter based on whether the current command is recursive. If recursive
-     * include directories, if non-recursive exclude directories
-     * @return
-     */
-    private DirectoryStream.Filter<Path> createFilter() {
-        DirectoryStream.Filter<Path> filter;
-        if (this.recursive) {
-             filter = new DirectoryStream.Filter<Path>() {
-                @Override
-                public boolean accept(final Path entry) throws IOException {
-                    // for recursive call we do not filter anything out
-                    return true;
-                }
-            };
-        } else {
-            filter = new DirectoryStream.Filter<Path>() {
-                @Override
-                public boolean accept(final Path entry) throws IOException {
-                    boolean retVal = false;
-                    if (!Files.isDirectory(entry)) {
-                        if (extensions == null || extensions.length == 0) {
-                            retVal = true;
-                        } else {
-                            for (final String extension : extensions) {
-                                if (entry.getFileName().toString().endsWith("." + extension)) {
-                                    retVal = true;
-                                }
-                            }
-                        }
-                    }
-                    return retVal;
-                }
-            };
-        }
-        return filter;
-    }
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/Creator/DirectoryStreamFilterCreator.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/filter/Creator/DirectoryStreamFilterCreator.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package uk.gov.nationalarchives.droid.command.filter.Creator;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * A class to create DirectoryStream filter(s).
+ * @author sparkhi
+ */
+public class DirectoryStreamFilterCreator {
+
+    private static final String STRING_DOT = ".";
+    private final boolean recursive;
+    private final String[] extensions;
+
+
+    /**
+     * Parameterized constructor to either create a recursive or non-recursive filter with extensions
+     * if recursive, include directories, if non-recursive exclude directories.
+     * @param recursive whether the filter would be used to recurse folders
+     * @param extensions array of extensions to filter
+     */
+    public DirectoryStreamFilterCreator(boolean recursive, String[] extensions) {
+        this.recursive = recursive;
+        this.extensions = extensions;
+    }
+
+    /**
+     * Default constructor recursing false, and no extension filtering.
+     */
+    public DirectoryStreamFilterCreator() {
+        this(false, null);
+    }
+
+    /**
+     * Create a filter for the directories. The filter operates on following criteria
+     *      1) Accepts all directories if recursive
+     *      2) Accept all files if not-recursive
+     *      3) Accept all files matching extension(s) and all directories if recursive and has extension filter
+     *      4) Accepts all files matching extension(s) if not recursive and has extension filter
+     * @return filter
+     */
+    public DirectoryStream.Filter<Path> create() {
+        DirectoryStream.Filter<Path> filter;
+        if (this.recursive) {
+            filter = new DirectoryStream.Filter<Path>() {
+                @Override
+                public boolean accept(final Path entry) throws IOException {
+                    boolean retVal = true; //for recurse, return everything unless known otherwise
+                    if (!Files.isDirectory(entry)) {
+                        if (extensions == null || extensions.length == 0) {
+                            retVal = true;
+                        } else {
+                            retVal = false; //there's a filter, we will accept only when matched
+                            for (final String extension : extensions) {
+                                if (entry.getFileName().toString().endsWith(STRING_DOT + extension)) {
+                                    retVal = true;
+                                }
+                            }
+                        }
+                    }
+                    return retVal;
+                }
+            };
+        } else {
+            filter = new DirectoryStream.Filter<Path>() {
+                @Override
+                public boolean accept(final Path entry) throws IOException {
+                    boolean retVal = false; //non recursion, we only accept what matches the filter
+                    if (!Files.isDirectory(entry)) {
+                        if (extensions == null || extensions.length == 0) {
+                            retVal = true;
+                        } else {
+                            for (final String extension : extensions) {
+                                if (entry.getFileName().toString().endsWith(STRING_DOT + extension)) {
+                                    retVal = true;
+                                }
+                            }
+                        }
+                    }
+                    return retVal;
+                }
+            };
+        }
+        return filter;
+    }
+}

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/filter/Creator/DirectoryStreamFilterCreatorTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/filter/Creator/DirectoryStreamFilterCreatorTest.java
@@ -56,6 +56,15 @@ public class DirectoryStreamFilterCreatorTest {
 
     @Rule
     public TemporaryFolder tempRoot = new TemporaryFolder();
+    private File root_flying_gif;
+    private File root_indiaNa_jpeg;
+    private File root_rocket_gif;
+    private File root_tna_icon_png;
+    private File root_tna_jpeg;
+    private File root_oneMore_flying_gif;
+    private File root_oneMore_tna_icon_png;
+    private File root_oneMore_tna_jpeg;
+    private File oneMoreFolder;
 
     /**
      * The structure being used for these tests is
@@ -82,17 +91,17 @@ public class DirectoryStreamFilterCreatorTest {
      */
     @Before
     public void setupFoldersAndFiles() throws IOException {
-        File oneMoreFolder = tempRoot.newFolder("one-more");
+        oneMoreFolder = tempRoot.newFolder("one-more");
         oneMoreFolder.mkdir();
 
-        tempRoot.newFile("flying.gif");
-        tempRoot.newFile("india-na.jpeg");
-        tempRoot.newFile("rocket.gif");
-        tempRoot.newFile("the_national_archives_icon.png");
-        tempRoot.newFile("tna.jpeg");
-        tempRoot.newFile("one-more/flying.gif");
-        tempRoot.newFile("one-more/the_national_archives_icon.png");
-        tempRoot.newFile("one-more/tna.jpeg");
+        root_flying_gif = tempRoot.newFile("flying.gif");
+        root_indiaNa_jpeg = tempRoot.newFile("india-na.jpeg");
+        root_rocket_gif = tempRoot.newFile("rocket.gif");
+        root_tna_icon_png =  tempRoot.newFile("the_national_archives_icon.png");
+        root_tna_jpeg = tempRoot.newFile("tna.jpeg");
+        root_oneMore_flying_gif = tempRoot.newFile("one-more/flying.gif");
+        root_oneMore_tna_icon_png = tempRoot.newFile("one-more/the_national_archives_icon.png");
+        root_oneMore_tna_jpeg = tempRoot.newFile("one-more/tna.jpeg");
     }
 
     @Test
@@ -100,11 +109,8 @@ public class DirectoryStreamFilterCreatorTest {
         List<Path> paths = getPathList(false, null);
         assertEquals(5, paths.size());
 
-        List<String> expectedPaths = Arrays.asList(tempRoot.getRoot().getPath() + "/tna.jpeg",
-                tempRoot.getRoot().getPath() + "/india-na.jpeg",
-                tempRoot.getRoot().getPath() + "/rocket.gif",
-                tempRoot.getRoot().getPath() + "/the_national_archives_icon.png",
-                tempRoot.getRoot().getPath() + "/flying.gif");
+        List<String> expectedPaths = Arrays.asList(root_tna_jpeg.getPath(), root_indiaNa_jpeg.getPath(),
+                root_rocket_gif.getPath(), root_tna_icon_png.getPath(), root_flying_gif.getPath());
 
         List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
         assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
@@ -115,12 +121,8 @@ public class DirectoryStreamFilterCreatorTest {
         List<Path> paths = getPathList(true, null);
         assertEquals(6, paths.size());
 
-        List<String> expectedPaths = Arrays.asList(tempRoot.getRoot().getPath() + "/tna.jpeg",
-                tempRoot.getRoot().getPath() + "/india-na.jpeg",
-                tempRoot.getRoot().getPath() + "/rocket.gif",
-                tempRoot.getRoot().getPath() + "/the_national_archives_icon.png",
-                tempRoot.getRoot().getPath() + "/flying.gif",
-                tempRoot.getRoot().getPath() + "/one-more");
+        List<String> expectedPaths = Arrays.asList(root_tna_jpeg.getPath(), root_indiaNa_jpeg.getPath(),
+                root_rocket_gif.getPath(), root_tna_icon_png.getPath(), root_flying_gif.getPath(), oneMoreFolder.getPath());
 
         List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
         assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
@@ -131,9 +133,7 @@ public class DirectoryStreamFilterCreatorTest {
         List<Path> paths = getPathList(false, new String[] {"gif"});
         assertEquals(2, paths.size());
 
-        List<String> expectedPaths = Arrays.asList(
-                tempRoot.getRoot().getPath() + "/rocket.gif",
-                tempRoot.getRoot().getPath() + "/flying.gif");
+        List<String> expectedPaths = Arrays.asList(root_rocket_gif.getPath(), root_flying_gif.getPath());
 
         List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
         assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
@@ -144,10 +144,8 @@ public class DirectoryStreamFilterCreatorTest {
         List<Path> paths = getPathList(true, new String[] {"gif"});
         assertEquals(3, paths.size());
 
-        List<String> expectedPaths = Arrays.asList(
-                tempRoot.getRoot().getPath() + "/rocket.gif",
-                tempRoot.getRoot().getPath() + "/flying.gif",
-                tempRoot.getRoot().getPath() + "/one-more");
+        List<String> expectedPaths = Arrays.asList(root_rocket_gif.getPath(), root_flying_gif.getPath(),
+                oneMoreFolder.getPath());
 
         List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
         assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
@@ -158,12 +156,8 @@ public class DirectoryStreamFilterCreatorTest {
         List<Path> paths = getPathList(true, new String[] {"gif", "jpeg"});
         assertEquals(5, paths.size());
 
-        List<String> expectedPaths = Arrays.asList(
-                tempRoot.getRoot().getPath() + "/rocket.gif",
-                tempRoot.getRoot().getPath() + "/flying.gif",
-                tempRoot.getRoot().getPath() + "/one-more",
-                tempRoot.getRoot().getPath() + "/tna.jpeg",
-                tempRoot.getRoot().getPath() + "/india-na.jpeg");
+        List<String> expectedPaths = Arrays.asList(root_rocket_gif.getPath(), root_flying_gif.getPath(),
+                oneMoreFolder.getPath(), root_tna_jpeg.getPath(), root_indiaNa_jpeg.getPath());
 
         List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
         assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/filter/Creator/DirectoryStreamFilterCreatorTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/filter/Creator/DirectoryStreamFilterCreatorTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package uk.gov.nationalarchives.droid.command.filter.Creator;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+
+
+public class DirectoryStreamFilterCreatorTest {
+
+    @Rule
+    public TemporaryFolder tempRoot = new TemporaryFolder();
+
+    /**
+     * The structure being used for these tests is
+     *    rootFolder
+     *       |
+     *       + flying.gif
+     *       |
+     *       + india-na.jpeg
+     *       |
+     *       + rocket.gif
+     *       |
+     *       + the_national_archives_icon.png
+     *       |
+     *       + tna.jpeg
+     *       |
+     *       +--------~ one-more
+     *                     |
+     *                     + flying.gif
+     *                     |
+     *                     + the_national_archives_icon.png
+     *                     |
+     *                     + tna.jpeg
+     *
+     */
+    @Before
+    public void setupFoldersAndFiles() throws IOException {
+        File oneMoreFolder = tempRoot.newFolder("one-more");
+        oneMoreFolder.mkdir();
+
+        tempRoot.newFile("flying.gif");
+        tempRoot.newFile("india-na.jpeg");
+        tempRoot.newFile("rocket.gif");
+        tempRoot.newFile("the_national_archives_icon.png");
+        tempRoot.newFile("tna.jpeg");
+        tempRoot.newFile("one-more/flying.gif");
+        tempRoot.newFile("one-more/the_national_archives_icon.png");
+        tempRoot.newFile("one-more/tna.jpeg");
+    }
+
+    @Test
+    public void shouldFilterAllFilesInCurrentFolderWhenThereIsNoExtensionFilterAndRecursiveIsFalse() throws IOException {
+        List<Path> paths = getPathList(false, null);
+        assertEquals(5, paths.size());
+
+        List<String> expectedPaths = Arrays.asList(tempRoot.getRoot().getPath() + "/tna.jpeg",
+                tempRoot.getRoot().getPath() + "/india-na.jpeg",
+                tempRoot.getRoot().getPath() + "/rocket.gif",
+                tempRoot.getRoot().getPath() + "/the_national_archives_icon.png",
+                tempRoot.getRoot().getPath() + "/flying.gif");
+
+        List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
+        assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
+    }
+
+    @Test
+    public void shouldFilterAllFilesAndFolderWhenRecursingAndNoFilterOnExtension() throws IOException {
+        List<Path> paths = getPathList(true, null);
+        assertEquals(6, paths.size());
+
+        List<String> expectedPaths = Arrays.asList(tempRoot.getRoot().getPath() + "/tna.jpeg",
+                tempRoot.getRoot().getPath() + "/india-na.jpeg",
+                tempRoot.getRoot().getPath() + "/rocket.gif",
+                tempRoot.getRoot().getPath() + "/the_national_archives_icon.png",
+                tempRoot.getRoot().getPath() + "/flying.gif",
+                tempRoot.getRoot().getPath() + "/one-more");
+
+        List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
+        assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
+    }
+
+    @Test
+    public void shouldFilterOnlyTheFilesMatchingExtensionWhenNotRecursing() throws IOException {
+        List<Path> paths = getPathList(false, new String[] {"gif"});
+        assertEquals(2, paths.size());
+
+        List<String> expectedPaths = Arrays.asList(
+                tempRoot.getRoot().getPath() + "/rocket.gif",
+                tempRoot.getRoot().getPath() + "/flying.gif");
+
+        List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
+        assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
+    }
+
+    @Test
+    public void shouldFilterOnlyTheFilesMatchingExtensionAndFoldersWhenRecursing() throws IOException {
+        List<Path> paths = getPathList(true, new String[] {"gif"});
+        assertEquals(3, paths.size());
+
+        List<String> expectedPaths = Arrays.asList(
+                tempRoot.getRoot().getPath() + "/rocket.gif",
+                tempRoot.getRoot().getPath() + "/flying.gif",
+                tempRoot.getRoot().getPath() + "/one-more");
+
+        List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
+        assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
+    }
+
+    @Test
+    public void shouldFilterAllTheFilesMatchingMultipleExtensionAndFoldersWhenRecursing() throws IOException {
+        List<Path> paths = getPathList(true, new String[] {"gif", "jpeg"});
+        assertEquals(5, paths.size());
+
+        List<String> expectedPaths = Arrays.asList(
+                tempRoot.getRoot().getPath() + "/rocket.gif",
+                tempRoot.getRoot().getPath() + "/flying.gif",
+                tempRoot.getRoot().getPath() + "/one-more",
+                tempRoot.getRoot().getPath() + "/tna.jpeg",
+                tempRoot.getRoot().getPath() + "/india-na.jpeg");
+
+        List<String> actualPaths = paths.stream().map(a -> a.toString()).collect(Collectors.toList());
+        assertThat(actualPaths, containsInAnyOrder(expectedPaths.toArray()));
+    }
+
+    /**
+     * Private helper method for manipulating the iterator into a testable list.
+     * @param recursive whether the filter is recursive
+     * @param extensions whether the filter has extensions
+     * @return filtered Paths as a List
+     * @throws IOException
+     */
+    private List<Path> getPathList(boolean recursive, String[] extensions) throws IOException {
+        DirectoryStreamFilterCreator creator = new DirectoryStreamFilterCreator(recursive, extensions);
+        DirectoryStream.Filter<Path> dirStreamFilter = creator.create();
+
+        DirectoryStream<Path> filteredStream = Files.newDirectoryStream(tempRoot.getRoot().toPath(), dirStreamFilter);
+        return StreamSupport.stream(filteredStream.spliterator(), false).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Fix for #425 

Moved the DirectoryStream filter creation out of the command line class and implemented the differences based on whether we are recursing or not. Added unit tests to cover existing as well as amended scenario 

### Acceptance Tests
Setup:
Create a folder structure and setup a few files as follows (easy to get a variety on image files)
```
     *    test-files
     *       |
     *       + flying.gif
     *       |
     *       + india-na.jpeg
     *       |
     *       + rocket.gif
     *       |
     *       + the_national_archives_icon.png
     *       |
     *       + tna.jpeg
     *       |
     *       +--------- one-more
     *                     |
     *                     + flying.gif
     *                     |
     *                     + the_national_archives_icon.png
     *                     |
     *                     + tna.jpeg
```

1. Run droid CLI with following parameters 
`-Nr "/test-data/test-files" -Ns "<droid-signature-file-from-your-location>" -R -Nx gif`
It should report all the gif files from 'test-files' as well as 'test-files/one-more' 

2. Run droid CLI with following parameters 
`-Nr "/test-data/test-files" -Ns "<droid-signature-file-from-your-location>"  -Nx gif`
It should report all the gif files from 'test-files' but not from 'test-files/one-more' 

3. Run droid CLI with following parameters 
`-Nr "/test-data/test-files" -Ns "<droid-signature-file-from-your-location>"`
It should report all the files from 'test-files' but not from 'test-files/one-more' 

4. Run droid CLI with following parameters 
`-Nr "/test-data/test-files" -Ns "<droid-signature-file-from-your-location>"  -R`
It should report all the files from 'test-files' and also all the files from 'test-files/one-more' 