### PR TITLE
Fix graphical glitches on Windows 10

### DIFF
--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.form
@@ -731,6 +731,17 @@
           </Events>
         </Component>
         <Container class="javax.swing.JPanel" name="jPanel1">
+          <Properties>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[24, 60]"/>
+            </Property>
+            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[24, 60]"/>
+            </Property>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[24, 60]"/>
+            </Property>
+          </Properties>
 
           <Layout>
             <DimensionLayout dim="0">
@@ -744,8 +755,8 @@
             <DimensionLayout dim="1">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
-                      <Component id="jFilterOnCheckBox" min="-2" pref="50" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                      <Component id="jFilterOnCheckBox" max="32767" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -757,8 +768,14 @@
                 <Property name="focusable" type="boolean" value="false"/>
                 <Property name="horizontalTextPosition" type="int" value="0"/>
                 <Property name="inheritsPopupMenu" type="boolean" value="true"/>
+                <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[24, 55]"/>
+                </Property>
+                <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[24, 55]"/>
+                </Property>
                 <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-                  <Dimension value="[24, 58]"/>
+                  <Dimension value="[24, 55]"/>
                 </Property>
                 <Property name="verticalAlignment" type="int" value="3"/>
                 <Property name="verticalTextPosition" type="int" value="3"/>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.form
@@ -5,7 +5,7 @@
     <Menu class="javax.swing.JMenuBar" name="jMenuBar1">
       <Properties>
         <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[100, 21]"/>
+          <Dimension value="[100, 25]"/>
         </Property>
       </Properties>
       <SubComponents>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
@@ -609,11 +609,17 @@ public class DroidMainFrame extends JFrame {
         });
         droidToolBar.add(jButtonFilter);
 
+        jPanel1.setMaximumSize(new java.awt.Dimension(24, 60));
+        jPanel1.setMinimumSize(new java.awt.Dimension(24, 60));
+        jPanel1.setPreferredSize(new java.awt.Dimension(24, 60));
+
         jFilterOnCheckBox.setText("On");
         jFilterOnCheckBox.setFocusable(false);
         jFilterOnCheckBox.setHorizontalTextPosition(javax.swing.SwingConstants.CENTER);
         jFilterOnCheckBox.setInheritsPopupMenu(true);
-        jFilterOnCheckBox.setPreferredSize(new java.awt.Dimension(24, 58));
+        jFilterOnCheckBox.setMaximumSize(new java.awt.Dimension(24, 55));
+        jFilterOnCheckBox.setMinimumSize(new java.awt.Dimension(24, 55));
+        jFilterOnCheckBox.setPreferredSize(new java.awt.Dimension(24, 55));
         jFilterOnCheckBox.setVerticalAlignment(javax.swing.SwingConstants.BOTTOM);
         jFilterOnCheckBox.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
         jFilterOnCheckBox.addActionListener(new java.awt.event.ActionListener() {
@@ -633,8 +639,8 @@ public class DroidMainFrame extends JFrame {
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jPanel1Layout.createSequentialGroup()
-                .addComponent(jFilterOnCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, 50, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(0, 0, Short.MAX_VALUE))
+                .addComponent(jFilterOnCheckBox, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addContainerGap())
         );
 
         droidToolBar.add(jPanel1);

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
@@ -655,7 +655,7 @@ public class DroidMainFrame extends JFrame {
         });
         droidToolBar.add(jButtonReport);
 
-        jMenuBar1.setPreferredSize(new java.awt.Dimension(100, 21));
+        jMenuBar1.setPreferredSize(new java.awt.Dimension(100, 25));
 
         jMenuFile.setMnemonic('F');
         jMenuFile.setText("File");

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.form
@@ -190,7 +190,7 @@
                       </Group>
                       <EmptySpace type="unrelated" max="-2" attributes="0"/>
                       <Component id="jLabel10" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="142" max="32767" attributes="0"/>
+                      <EmptySpace pref="156" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -657,7 +657,7 @@
                       <Group type="102" alignment="1" attributes="0">
                           <EmptySpace max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="1" attributes="0">
-                              <Component id="rowPerFormatButton1" pref="548" max="32767" attributes="0"/>
+                              <Component id="rowPerFormatButton1" max="32767" attributes="0"/>
                               <Component id="rowPerFileButton1" max="32767" attributes="0"/>
                           </Group>
                           <EmptySpace max="-2" attributes="0"/>
@@ -670,7 +670,7 @@
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="rowPerFileButton1" min="-2" max="-2" attributes="0"/>
                           <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                          <Component id="rowPerFormatButton1" min="-2" pref="15" max="-2" attributes="0"/>
+                          <Component id="rowPerFormatButton1" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="32767" attributes="0"/>
                       </Group>
                   </Group>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
@@ -620,7 +620,7 @@ public class ConfigDialog extends JDialog {
                     .addComponent(jLabel4))
                 .addPreferredGap(ComponentPlacement.UNRELATED)
                 .addComponent(jLabel10)
-                .addContainerGap(142, Short.MAX_VALUE))
+                .addContainerGap(156, Short.MAX_VALUE))
         );
 
         generalTabbedPane1.addTab(NbBundle.getMessage(ConfigDialog.class, "ConfigDialog.jPanel2.TabConstraints.tabTitle"), jPanel3); // NOI18N
@@ -651,7 +651,7 @@ public class ConfigDialog extends JDialog {
             .addGroup(Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(jPanel1Layout.createParallelGroup(Alignment.TRAILING)
-                    .addComponent(rowPerFormatButton1, GroupLayout.DEFAULT_SIZE, 548, Short.MAX_VALUE)
+                    .addComponent(rowPerFormatButton1, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(rowPerFileButton1, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
         );
@@ -660,7 +660,7 @@ public class ConfigDialog extends JDialog {
                 .addContainerGap()
                 .addComponent(rowPerFileButton1)
                 .addPreferredGap(ComponentPlacement.UNRELATED)
-                .addComponent(rowPerFormatButton1, GroupLayout.PREFERRED_SIZE, 15, GroupLayout.PREFERRED_SIZE)
+                .addComponent(rowPerFormatButton1)
                 .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterDialog.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterDialog.form
@@ -36,17 +36,17 @@
               <Component id="jPanel1" max="32767" attributes="0"/>
           </Group>
           <Component id="jPanel2" alignment="0" min="0" max="32767" attributes="2"/>
-          <Group type="102" alignment="0" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jScrollPane1" pref="656" max="32767" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
+                      <Component id="jScrollPane1" pref="656" max="32767" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <Component id="jPanel2" min="-2" pref="29" max="-2" attributes="0"/>
+              <Component id="jPanel2" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jScrollPane1" pref="200" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filter/FilterDialog.java
@@ -600,10 +600,10 @@ public class FilterDialog extends JDialog {
             }
         ));
         jScrollPane1.setViewportView(filterTable);
-        filterTable.getColumnModel().getColumn(0).setHeaderValue(org.openide.util.NbBundle.getMessage(FilterDialog.class, "FilterDialog.jTable1.columnModel.title0")); // NOI18N
-        filterTable.getColumnModel().getColumn(1).setHeaderValue(org.openide.util.NbBundle.getMessage(FilterDialog.class, "FilterDialog.jTable1.columnModel.title1")); // NOI18N
-        filterTable.getColumnModel().getColumn(2).setHeaderValue(org.openide.util.NbBundle.getMessage(FilterDialog.class, "FilterDialog.jTable1.columnModel.title2")); // NOI18N
-        filterTable.getColumnModel().getColumn(3).setHeaderValue(org.openide.util.NbBundle.getMessage(FilterDialog.class, "FilterDialog.jTable1.columnModel.title3")); // NOI18N
+            filterTable.getColumnModel().getColumn(0).setHeaderValue(org.openide.util.NbBundle.getMessage(FilterDialog.class, "FilterDialog.jTable1.columnModel.title0")); // NOI18N
+            filterTable.getColumnModel().getColumn(1).setHeaderValue(org.openide.util.NbBundle.getMessage(FilterDialog.class, "FilterDialog.jTable1.columnModel.title1")); // NOI18N
+            filterTable.getColumnModel().getColumn(2).setHeaderValue(org.openide.util.NbBundle.getMessage(FilterDialog.class, "FilterDialog.jTable1.columnModel.title2")); // NOI18N
+            filterTable.getColumnModel().getColumn(3).setHeaderValue(org.openide.util.NbBundle.getMessage(FilterDialog.class, "FilterDialog.jTable1.columnModel.title3")); // NOI18N
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
@@ -615,13 +615,13 @@ public class FilterDialog extends JDialog {
             .addComponent(jPanel2, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 656, Short.MAX_VALUE)
+                        .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 656, Short.MAX_VALUE)
                 .addContainerGap())
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, 29, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 200, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportDialog.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportDialog.form
@@ -57,9 +57,9 @@
                   <Component id="reportSelectLabel" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace type="separate" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="cancelButton" alignment="3" min="-2" pref="23" max="-2" attributes="0"/>
-                  <Component id="generateButton" alignment="3" min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                  <Component id="generateButton" max="32767" attributes="0"/>
+                  <Component id="cancelButton" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportDialog.java
@@ -36,6 +36,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.swing.DefaultCellEditor;
@@ -101,6 +102,7 @@ public class ReportDialog extends JDialog {
         for (ProfileForm profile : profiles) {
             profilesRowData.add(new ProfileWrapper(profile));
         }
+        profilesRowData.sort(Comparator.comparing(profileWrapper -> profileWrapper.getProfile().getProfile().getName()));
         
         tableModel = new DefaultTableModel(0, 1) {
             @Override
@@ -134,6 +136,7 @@ public class ReportDialog extends JDialog {
         DefaultComboBoxModel model = new DefaultComboBoxModel();
         
         final List<ReportSpec> reports = droidMain.getGlobalContext().getReportManager().listReportSpecs();
+        reports.sort(Comparator.comparing(ReportSpec::getName));
         for (ReportSpec reportSpec : reports) {
             model.addElement(reportSpec);
         }
@@ -327,9 +330,6 @@ public class ReportDialog extends JDialog {
         private static final long serialVersionUID = 8023412072260282004L;
         private ProfileWrapper profile;
         
-        /**
-         * @param checkBox
-         */
         public CheckBoxEditor() {
             super(new JCheckBox());
         }

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/report/ReportDialog.java
@@ -188,6 +188,7 @@ public class ReportDialog extends JDialog {
         reportSelectCombo = new JComboBox();
 
         setTitle(NbBundle.getMessage(ReportDialog.class, "ReportDialog.title_1")); // NOI18N
+
         cancelButton.setText(NbBundle.getMessage(ReportDialog.class, "ReportDialog.cancelButton.text")); // NOI18N
         cancelButton.setVerticalAlignment(SwingConstants.BOTTOM);
         cancelButton.addActionListener(new ActionListener() {
@@ -204,6 +205,7 @@ public class ReportDialog extends JDialog {
         });
 
         profileSelectLabel.setText(NbBundle.getMessage(ReportDialog.class, "ReportDialog.profileSelectLabel.text_1")); // NOI18N
+
         profileSelectTable.setModel(new DefaultTableModel(
             new Object [][] {
 
@@ -219,14 +221,13 @@ public class ReportDialog extends JDialog {
         profileSelectTable.setTableHeader(null);
         jScrollPane1.setViewportView(profileSelectTable);
 
-
         reportSelectLabel.setText(NbBundle.getMessage(ReportDialog.class, "ReportDialog.reportSelectLabel.text")); // NOI18N
+
         reportSelectCombo.setModel(new DefaultComboBoxModel(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
 
         GroupLayout layout = new GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(Alignment.TRAILING, layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(Alignment.TRAILING)
@@ -242,8 +243,7 @@ public class ReportDialog extends JDialog {
                         .addComponent(reportSelectCombo, 0, 384, Short.MAX_VALUE)))
                 .addContainerGap())
         );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setVerticalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(profileSelectLabel)
@@ -254,9 +254,9 @@ public class ReportDialog extends JDialog {
                     .addComponent(reportSelectCombo, GroupLayout.PREFERRED_SIZE, 20, GroupLayout.PREFERRED_SIZE)
                     .addComponent(reportSelectLabel))
                 .addGap(18, 18, 18)
-                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                    .addComponent(cancelButton, GroupLayout.PREFERRED_SIZE, 23, GroupLayout.PREFERRED_SIZE)
-                    .addComponent(generateButton))
+                .addGroup(layout.createParallelGroup(Alignment.LEADING, false)
+                    .addComponent(generateButton, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(cancelButton, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents


### PR DESCRIPTION
# Issue 
fix https://github.com/digital-preservation/droid/issues/427

  - [X] filter screen first row is trimmed “All any filter enabled”,
  - [X] preference > export defaults: one row per format button trimmed
  - [X] main screen: could have more space between top menu “File Edit…” and buttons “New Open…”
  - [X] main screen: the report icon is pushed far the the rhs of the window.
  - [x] report on profiles: need more space between profiles to reports on, also wrong order

# Acceptances tests
Check every single point above on Windows 10