### PR TITLE
fix: iso prefix in CLI when expanding ISO archives

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/archive/IsoArchiveContainerIdentifier.java
@@ -81,7 +81,7 @@ public class IsoArchiveContainerIdentifier extends ArchiveContentIdentifier {
      */
     public void identify(final URI uri, final IdentificationRequest request) throws CommandExecutionException {
 
-        final String newPath = makeContainerURI("zip", request.getFileName());
+        final String newPath = makeContainerURI("iso", request.getFileName());
         setSlash1("");
 
         if (request.getClass().isAssignableFrom(FileSystemIdentificationRequest.class)) {


### PR DESCRIPTION
# Issue
fix https://github.com/digital-preservation/droid/issues/433
prefix in CLI was wrong when expanding ISO archives, showing "zip" instead of "iso"

# Acceptance tests
- Run in CLI the following on a folder including ISO and TAR archives (or any other than TAR - change CLI accordingly)
- check output, make sure error from Paul is corrected (and we see iso at the beginning of lines mentioning the analysis of first children in ISO archives)
```
-Nr /home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/ -Ns /home/jeremie/.droid6.5/signature_files/DROID_SignatureFile_V96.xml -At ISO TAR
```

expected output:
```
/home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso,fmt/468
iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/custom sample.rar,fmt/411
iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.7z,fmt/484
iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.iso,fmt/468
2020-03-27T10:22:37,449  INFO [main] IsoArchiveContainerIdentifier:103 - Identification request for ISO image ignored due to limited support.
iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.tar,x-fmt/265
tar:/iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.tar!/Screenshot from 2020-01-22 21-36-16.png,fmt/11
tar:/iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.tar!/Submission format.xlsx,x-fmt/263
tar:/iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.tar!/Submission format.csv,Unknown
iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.zip,x-fmt/263
iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.tar.bz2,x-fmt/268
iso://home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.iso!/samples.tar.gz,x-fmt/266
/home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.zip,x-fmt/263
/home/jeremie/Documents/drive_TNA/droid/samples/archive-parents/archive-parent.tar.gz,x-fmt/266
```