### PR TITLE
fix: put back LF (unix) line separators in csv exports

### DIFF
--- a/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/CsvItemWriter.java
+++ b/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/CsvItemWriter.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang.time.FastDateFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.univocity.parsers.csv.CsvFormat;
 import com.univocity.parsers.csv.CsvWriter;
 import com.univocity.parsers.csv.CsvWriterSettings;
 import com.univocity.parsers.common.TextWritingException;
@@ -219,6 +220,10 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
     public void open(final Writer writer) {
         final CsvWriterSettings csvWriterSettings = new CsvWriterSettings();
         csvWriterSettings.setQuoteAllFields(true);
+        CsvFormat format = new CsvFormat();
+        // following Unix convention on line separators as previously
+        format.setLineSeparator("\n");
+        csvWriterSettings.setFormat(format);
         csvWriter = new CsvWriter(writer, csvWriterSettings);
         if (headers == null) {
             headers = HEADERS;

--- a/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/CsvItemWriterTest.java
+++ b/droid-export/src/test/java/uk/gov/nationalarchives/droid/export/CsvItemWriterTest.java
@@ -75,7 +75,7 @@ import uk.gov.nationalarchives.droid.profile.referencedata.Format;
 public class CsvItemWriterTest {
 
 	private static DateTime testDateTime = new DateTime(12345678L);
-	private static final String LINE_SEPARATOR = System.getProperty("line.separator", "\n");
+	private static final String LINE_SEPARATOR = "\n";
     private CsvItemWriter itemWriter;
     private File destination;
     private DroidGlobalConfig config;


### PR DESCRIPTION
# Issue 
Fix #440 

# Context 
this is new in 6.5.

This is due to a change in the library used to create CSV format (done by @adamretter to improve processing speed).
The library by default outputs files in a different format according to the operating system (using the operating system's own convention), while the previous one just used Unix format.

```
https://github.com/uniVocity/univocity-parsers/blob/master/src/main/java/com/univocity/parsers/common/Format.java
 *  <li><b>lineSeparator:</b> the 1-2 character sequence that indicates the end of a line. Newline sequences are different across operating systems. Typically:
 *		<ul>
 *			<li>Windows uses carriage return and line feed: <i>\r\n</i></li>
 *			<li>Linux/Unix uses line feed only: <i>\n</i></li>
 *			<li>MacOS uses carriage return only: <i>\r</i></li>
 *		</ul>
 *   	<i>{@link Format#lineSeparator} defaults to the system line separator</i>
 *  </li>
```

# Solution
manually set the CSV format back to Unix.

# Acceptance tests
- start GUI in Windows
- run analysis on random files
- export CSV
- verify that CSV files use LF (Unix) line separating instead of CRLF (Windows)
