### PR TITLE
nio File based POIFS is optimized for memory, 

### DIFF
--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
@@ -31,27 +31,14 @@
  */
 package uk.gov.nationalarchives.droid.command;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.PrintWriter;
-
 import junit.framework.Assert;
-
-import org.apache.commons.cli.AlreadySelectedException;
-import org.slf4j.LoggerFactory;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
 import uk.gov.nationalarchives.droid.command.action.CheckSignatureUpdateCommand;
 import uk.gov.nationalarchives.droid.command.action.CommandFactory;
 import uk.gov.nationalarchives.droid.command.action.CommandLineException;
-import uk.gov.nationalarchives.droid.command.action.CommandLineSyntaxException;
 import uk.gov.nationalarchives.droid.command.action.ConfigureDefaultSignatureFileVersionCommand;
 import uk.gov.nationalarchives.droid.command.action.DisplayDefaultSignatureFileVersionCommand;
 import uk.gov.nationalarchives.droid.command.action.DownloadSignatureUpdateCommand;
@@ -66,6 +53,14 @@ import uk.gov.nationalarchives.droid.command.filter.CommandLineFilter;
 import uk.gov.nationalarchives.droid.command.filter.CommandLineFilter.FilterType;
 import uk.gov.nationalarchives.droid.core.interfaces.config.RuntimeConfig;
 import uk.gov.nationalarchives.droid.export.interfaces.ExportOptions;
+
+import java.io.PrintWriter;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author rflitcroft
@@ -297,10 +292,10 @@ public class DroidCommandLineTest {
         DroidCommandLine droidCommandLine = new DroidCommandLine(args, printWriter);
         
         droidCommandLine.setContext(context);
-        
+
         droidCommandLine.processExecution();
-        verify(printWriter).println("Incorrect command line syntax: org.apache.commons.cli.AlreadySelectedException: The option 'v' was specified but an\n" +
-                "option from this group has already been selected: 'h'");
+        verify(printWriter).println("Incorrect command line syntax: org.apache.commons.cli.AlreadySelectedException: The option 'v' was specified but an" +
+                System.getProperty("line.separator") + "option from this group has already been selected: 'h'");
     }
     
     @Test

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
@@ -77,7 +77,7 @@ public class DroidCommandLineTest {
         context = mock(GlobalContext.class);
     }
     
-    @Test //(expected=CommandLineException.class)
+    @Test
     public void testParseNonsense() throws CommandLineException{
         String[] args = new String[] {
             "--zzzzzz"

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
@@ -82,16 +82,17 @@ public class DroidCommandLineTest {
         context = mock(GlobalContext.class);
     }
     
-    @Test (expected=CommandLineException.class)
+    @Test //(expected=CommandLineException.class)
     public void testParseNonsense() throws CommandLineException{
         String[] args = new String[] {
             "--zzzzzz"
         };
         
-        DroidCommandLine droidCommandLine = new DroidCommandLine(args);
+        DroidCommandLine droidCommandLine = new DroidCommandLine(args, printWriter);
         
         //a return code of 1 denotes a failure
         Assert.assertEquals(1, droidCommandLine.processExecution());
+        verify(printWriter).println("Incorrect command line syntax: org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: --zzzzzz");
         
     }
     
@@ -285,7 +286,7 @@ public class DroidCommandLineTest {
         
     }
 
-    @Test(expected=CommandLineException.class)
+    @Test
     public void testHelpAndVersionIsNotValidCombination() throws Exception {
         
         String[] args = new String[] {
@@ -293,11 +294,13 @@ public class DroidCommandLineTest {
             "-v"
         };
         
-        DroidCommandLine droidCommandLine = new DroidCommandLine(args);
+        DroidCommandLine droidCommandLine = new DroidCommandLine(args, printWriter);
         
         droidCommandLine.setContext(context);
         
         droidCommandLine.processExecution();
+        verify(printWriter).println("Incorrect command line syntax: org.apache.commons.cli.AlreadySelectedException: The option 'v' was specified but an\n" +
+                "option from this group has already been selected: 'h'");
     }
     
     @Test
@@ -369,7 +372,7 @@ public class DroidCommandLineTest {
         });
     }
     
-    @Test(expected = CommandLineException.class)
+    @Test
     public void testRunAndSaveProfileToMultipleFiles() throws CommandLineException {
         String[] args = new String[] {
             "-a",
@@ -383,9 +386,10 @@ public class DroidCommandLineTest {
         ProfileRunCommand command = mock(ProfileRunCommand.class);
         when(context.getProfileRunCommand()).thenReturn(command);
         
-        DroidCommandLine commandLine = new DroidCommandLine(args);
+        DroidCommandLine commandLine = new DroidCommandLine(args, printWriter);
         commandLine.processExecution();
-        
+
+        verify(printWriter).println("Incorrect command line syntax: Must specify exactly one profile.");
     }
 
     @Test
@@ -416,7 +420,7 @@ public class DroidCommandLineTest {
         verify(command).setRecursive(true);
     }
 
-    @Test(expected = CommandLineException.class)
+    @Test
     public void testRunAndSaveProfileWithNoProfileName() throws CommandLineException {
         String[] args = new String[] {
             "-a",
@@ -424,12 +428,12 @@ public class DroidCommandLineTest {
             "file/number/2.txt"
         };
         
-        DroidCommandLine commandLine = new DroidCommandLine(args);
+        DroidCommandLine commandLine = new DroidCommandLine(args, printWriter);
         commandLine.processExecution();
-
+        verify(printWriter).println("Incorrect command line syntax: Must specify exactly one profile.");
     }
 
-    @Test(expected = CommandLineException.class)
+    @Test
     public void testRunAndSaveProfileWithNoResources() throws CommandLineException {
         String[] args = new String[] {
             "-a",
@@ -437,9 +441,9 @@ public class DroidCommandLineTest {
             "test.droid"
         };
         
-        DroidCommandLine commandLine = new DroidCommandLine(args);
+        DroidCommandLine commandLine = new DroidCommandLine(args, printWriter);
         commandLine.processExecution();
-
+        verify(printWriter).println("Incorrect command line syntax: org.apache.commons.cli.MissingArgumentException: Missing argument for option: a");
     }
 
     
@@ -554,7 +558,7 @@ public class DroidCommandLineTest {
         verify(command).setSignatureFileVersion(99);
     }
 
-    @Test(expected = CommandLineSyntaxException.class)
+    @Test
     public void testConfigureDefaultSignatureFileVersionWithMissingValue() throws CommandLineException {
         
         String[] args = new String[] {
@@ -564,8 +568,9 @@ public class DroidCommandLineTest {
         ConfigureDefaultSignatureFileVersionCommand command = mock(ConfigureDefaultSignatureFileVersionCommand.class);
         when(context.getConfigureDefaultSignatureFileVersionCommand()).thenReturn(command);
         
-        DroidCommandLine commandLine = new DroidCommandLine(args);
+        DroidCommandLine commandLine = new DroidCommandLine(args, printWriter);
         commandLine.processExecution();
+        verify(printWriter).println("Incorrect command line syntax: org.apache.commons.cli.MissingArgumentException: Missing argument for option: s");
     }
     
     /**

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ole2/Ole2IdentifierEngine.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ole2/Ole2IdentifierEngine.java
@@ -69,26 +69,27 @@ public class Ole2IdentifierEngine extends AbstractIdentifierEngine {
     @Override
     public void process(IdentificationRequest request, ContainerSignatureMatchCollection matches) throws IOException {
         //CHECKSTYLE:ON
-        final InputStream in = request.getSourceInputStream();
+        InputStream in = null;
         POIFSFileSystem reader = null;
         try {
-            try {
-                if (FileSystemIdentificationRequest.class.isAssignableFrom(request.getClass())) {
-                    FileSystemIdentificationRequest req = FileSystemIdentificationRequest.class.cast(request);
-                    reader = new POIFSFileSystem(req.getFile().toFile());
-                } else {
+            if (FileSystemIdentificationRequest.class.isAssignableFrom(request.getClass())) {
+                FileSystemIdentificationRequest req = FileSystemIdentificationRequest.class.cast(request);
+                reader = new POIFSFileSystem(req.getFile().toFile());
+            } else {
+                try {
+                    in = request.getSourceInputStream();
                     reader = new POIFSFileSystem(in);
-                }
-            } finally {
-                // We can get Out Of Memory errors when attempting to instantiate the POIFSFileSystem.  However, these
-                // are handled internally by POIFS and not propogated to the calling code.  Therefore we check here
-                // whether the reader has been assigned - if not, this is probably due to an Out Of Memory error,
-                // possibly caused by a low heap size.
-                if (reader == null) {
-                    //request.getIdentifier() is null when running in command line 'no profile' mode.
-                    String identifier = request.getIdentifier() != null
-                            ? request.getIdentifier().getUri().toString() : "the current container file";
-                    throw new IOException(String.format(NO_READER_ERROR, identifier));
+                } finally {
+                    // We can get Out Of Memory errors when attempting to instantiate the POIFSFileSystem.  However, these
+                    // are handled internally by POIFS and not propogated to the calling code.  Therefore we check here
+                    // whether the reader has been assigned - if not, this is probably due to an Out Of Memory error,
+                    // possibly caused by a low heap size.
+                    if (reader == null) {
+                        //request.getIdentifier() is null when running in command line 'no profile' mode.
+                        String identifier = request.getIdentifier() != null
+                                ? request.getIdentifier().getUri().toString() : "the current container file";
+                        throw new IOException(String.format(NO_READER_ERROR, identifier));
+                    }
                 }
             }
 


### PR DESCRIPTION
so separated out the 2 error handling by whether we use file or InputStream.

This will make sure that we do not arbitrarily suggest increasing the memory. My analysis of the code indicated that the error message was introduced many years back when we used only `InputStream` this constructor's documentation indicated that it is more memory intensive and there are suggestions to use the constructor which takes in a `File`
We subsequently introduced that constructor (which uses nio) but the memory error message was kept in as it is. This PR separates the two. 

Helps with one part of https://github.com/digital-preservation/droid/issues/439