### PR TITLE
Prep release 6.5

### DIFF
--- a/droid-binary/bin/ChangeLog
+++ b/droid-binary/bin/ChangeLog
@@ -9,6 +9,8 @@ Version 6.5
 * bundle jre with windows
 * FatFile support
 
+For a full list of the included changes with this version, please check the full changelog (http://www.github.com/digital-preservation/droid/releases/tag/droid-6.5/)
+
 Version 6.3
 * Signature updates: Signature file release 88, Container file 20160927
 * Fixes for fragment offset issues:

--- a/droid-binary/pom.xml
+++ b/droid-binary/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
     
     <build>

--- a/droid-binary/pom.xml
+++ b/droid-binary/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
     
     <build>
@@ -56,11 +56,11 @@
                         <configuration>
                             <tasks>
                                 <!-- Update binary from https://adoptopenjdk.net/releases.html -->
-                                <unzip src="${project.build.directory}/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.5_10.zip" dest="${project.build.directory}/jre_tmp/"/>
+                                <unzip src="${project.build.directory}/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.5_10.zip" dest="${project.build.directory}/jre_tmp/" />
 
                                 <move todir="${project.build.directory}/jre-windows/">
                                     <fileset dir="${project.build.directory}/jre_tmp/jdk-11.0.5+10-jre/">
-                                        <include name="**/*"/>
+                                        <include name="**/*" />
                                     </fileset>
                                 </move>
 

--- a/droid-build-tools/pom.xml
+++ b/droid-build-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
 </project>

--- a/droid-build-tools/pom.xml
+++ b/droid-build-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
 </project>

--- a/droid-command-line/pom.xml
+++ b/droid-command-line/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
  
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-command-line/pom.xml
+++ b/droid-command-line/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
  
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-container/pom.xml
+++ b/droid-container/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-container/pom.xml
+++ b/droid-container/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/IdentificationRequest.java
@@ -87,7 +87,6 @@ public interface IdentificationRequest<T> extends Closeable {
      * 
      * @return an InputStream which will read the binary data which formed the source
      * of this request.  
-     * @return
      * @throws IOException  if there was an error reading from the binary source
      */
     InputStream getSourceInputStream() throws IOException;

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA1HashGenerator.java
@@ -44,7 +44,7 @@ public class SHA1HashGenerator implements HashGenerator {
 
     /**
      * {@inheritDoc}
-     * @throws java.io.IOException
+     * @throws java.io.IOException exception
      */
     @Override
     public String hash(InputStream in) throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA256HashGenerator.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/hash/SHA256HashGenerator.java
@@ -45,7 +45,7 @@ public class SHA256HashGenerator implements HashGenerator {
 
     /**
      * {@inheritDoc}
-     * @throws java.io.IOException
+     * @throws java.io.IOException exception
      */
     @Override
     public String hash(InputStream in) throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/BZipIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/BZipIdentificationRequest.java
@@ -132,7 +132,7 @@ public class BZipIdentificationRequest implements IdentificationRequest<InputStr
 
     /**
      * {@inheritDoc}
-     * @throws IOException
+     * @throws IOException exception
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/GZipIdentificationRequest.java
@@ -132,7 +132,7 @@ public class GZipIdentificationRequest implements IdentificationRequest<InputStr
 
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException exception
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/TarEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/TarEntryIdentificationRequest.java
@@ -136,7 +136,7 @@ public class TarEntryIdentificationRequest implements IdentificationRequest<Inpu
 
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException exception
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/WebArchiveEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/WebArchiveEntryIdentificationRequest.java
@@ -122,7 +122,7 @@ public class WebArchiveEntryIdentificationRequest implements IdentificationReque
 
     /**
      * {@inheritDoc}
-     * @throws IOException
+     * @throws IOException exception
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ZipEntryIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/ZipEntryIdentificationRequest.java
@@ -155,7 +155,7 @@ public class ZipEntryIdentificationRequest implements IdentificationRequest<Inpu
 
     /**
      * {@inheritDoc}
-     * @throws IOException 
+     * @throws IOException exception
      */
     @Override
     public final InputStream getSourceInputStream() throws IOException {

--- a/droid-core/pom.xml
+++ b/droid-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-core/pom.xml
+++ b/droid-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceCompiler.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceCompiler.java
@@ -57,7 +57,7 @@ import static uk.gov.nationalarchives.droid.core.signature.compiler.ByteSequence
 
 /**
  * class to compile a ByteSequence from a DROID syntax regular expression created by {@link ByteSequenceParser}.
- * <br/>
+ *
  * See main method {@link #compile(ByteSequence, String, ByteSequenceAnchor, CompileType)}.
  *
  * @author Matt Palmer
@@ -82,7 +82,6 @@ public final class ByteSequenceCompiler {
     /**
      * Compilation type to build the objects from the expression.
      *
-     * <br/>
      * The length of the anchoring sequences can be different - PRONOM only allows straight bytes in anchors.
      */
     public enum CompileType {

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SubSequence.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/SubSequence.java
@@ -137,7 +137,7 @@ import uk.gov.nationalarchives.droid.core.signature.xml.SimpleElement;
  * the BoyerMooreHorpsool (BMH) algorithm.  This is known as the
  * "anchor" sequence.  
  *
- * <p/>If necessary, it can include Left and 
+ * If necessary, it can include Left and
  * Right Fragments, which are parts of the extended string of
  * bytes which cannot be searched for using BMH.  These fragments
  * include features like alternative (A|B|C) and gaps in the 

--- a/droid-export-interfaces/pom.xml
+++ b/droid-export-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
    <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-export-interfaces/pom.xml
+++ b/droid-export-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
    <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-export/pom.xml
+++ b/droid-export/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-export/pom.xml
+++ b/droid-export/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-help/pom.xml
+++ b/droid-help/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
  
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
  
 </project>

--- a/droid-help/pom.xml
+++ b/droid-help/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
  
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
  
 </project>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -6,12 +6,12 @@
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>9</version>
-        <relativePath/>
+        <relativePath />
     </parent>
   
     <groupId>uk.gov.nationalarchives</groupId>
     <artifactId>droid-parent</artifactId>
-    <version>6.5-SNAPSHOT</version>
+    <version>6.5</version>
     <packaging>pom</packaging>
   
     <name>droid-parent</name>
@@ -72,7 +72,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
     
     <mailingLists>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -195,6 +195,11 @@
                             <artifactId>maven-scm-provider-gitexe</artifactId>
                             <version>1.11.2</version>
                         </dependency>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-api</artifactId>
+                            <version>1.11.2</version>
+                        </dependency>
                     </dependencies>
                 </plugin>
                 <plugin>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -460,6 +460,14 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                </configuration>
+            </plugin>
 <!-- N.B. sourceFileExcludes won't work till version 2.11 is released 
             <plugin>
     <groupId>org.apache.maven.plugins</groupId>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -11,7 +11,7 @@
   
     <groupId>uk.gov.nationalarchives</groupId>
     <artifactId>droid-parent</artifactId>
-    <version>6.5</version>
+    <version>6.6-SNAPSHOT</version>
     <packaging>pom</packaging>
   
     <name>droid-parent</name>
@@ -72,7 +72,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
     
     <mailingLists>

--- a/droid-report-interfaces/pom.xml
+++ b/droid-report-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
         
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-report-interfaces/pom.xml
+++ b/droid-report-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
         
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-report/pom.xml
+++ b/droid-report/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-report/pom.xml
+++ b/droid-report/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>droid-parent</artifactId>
 		<groupId>uk.gov.nationalarchives</groupId>
-		<version>6.5-SNAPSHOT</version>
+		<version>6.5</version>
 		<relativePath>../droid-parent</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
 		<developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
 		<url>scm:git:https://github.com/digital-preservation/droid.git</url>
-	  <tag>HEAD</tag>
+	  <tag>droid-6.5</tag>
 	</scm>
 
 	<properties>
@@ -90,7 +90,7 @@
 					<dependency>
 						<groupId>uk.gov.nationalarchives</groupId>
 						<artifactId>droid-build-tools</artifactId>
-						<version>6.5-SNAPSHOT</version>
+						<version>6.5</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>droid-parent</artifactId>
 		<groupId>uk.gov.nationalarchives</groupId>
-		<version>6.5</version>
+		<version>6.6-SNAPSHOT</version>
 		<relativePath>../droid-parent</relativePath>
 	</parent>
 
@@ -17,7 +17,7 @@
 		<connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
 		<developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
 		<url>scm:git:https://github.com/digital-preservation/droid.git</url>
-	  <tag>droid-6.5</tag>
+	  <tag>HEAD</tag>
 	</scm>
 
 	<properties>
@@ -90,7 +90,7 @@
 					<dependency>
 						<groupId>uk.gov.nationalarchives</groupId>
 						<artifactId>droid-build-tools</artifactId>
-						<version>6.5</version>
+						<version>6.6-SNAPSHOT</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSource.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datasource/DerbyPooledDataSource.java
@@ -66,7 +66,8 @@ public class DerbyPooledDataSource extends HikariDataSource {
     * Shuts down the database.  
     * Derby throws a SQLNonTransientConnectionException on a SUCCESSFUL shutdown of the
     * database (with SQLstate 08006), so we catch this and log as debug, otherwise as an error.
-    * @throws SQLException if the database could not be shutdown.
+     *
+    * catch SQLException if the database could not be shutdown.
     */
     @Override
     public void close() {

--- a/droid-swing-ui/pom.xml
+++ b/droid-swing-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-swing-ui/pom.xml
+++ b/droid-swing-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
   
     <build>
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-swing-ui/src/main/java/org/netbeans/swing/outline/TreePathSupport.java
+++ b/droid-swing-ui/src/main/java/org/netbeans/swing/outline/TreePathSupport.java
@@ -65,8 +65,6 @@ import java.util.List;
  * <code>ExtTreeWillExpandListener</code>, so such a listener may be notified
  * if some other listener vetoes a pending expansion event.
  *
- * <br/>
- * <br/>
  * <p>
  *     Hot fix for issue mentioned in https://github.com/digital-preservation/droid/issues/306#issuecomment-555434012
  *
@@ -83,7 +81,10 @@ public final class TreePathSupport {
     private List<TreeWillExpandListener> weListeners = new ArrayList<TreeWillExpandListener>();
     private AbstractLayoutCache layout;
     
-    /** Creates a new instance of TreePathSupport */
+    /** Creates a new instance of TreePathSupport
+     * @param mdl mdl
+     * @param layout layout
+     * */
     public TreePathSupport(OutlineModel mdl, AbstractLayoutCache layout) {
         this.layout = layout;
     }

--- a/droid-tools/pom.xml
+++ b/droid-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-        <tag>droid-6.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>
@@ -47,7 +47,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5</version>
+                        <version>6.6-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -83,17 +83,17 @@
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-core</artifactId>
-            <version>6.5</version>
+            <version>6.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-core-interfaces</artifactId>
-            <version>6.5</version>
+            <version>6.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-container</artifactId>
-            <version>6.5</version>
+            <version>6.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/droid-tools/pom.xml
+++ b/droid-tools/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
 
@@ -20,7 +18,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-        <tag>HEAD</tag>
+        <tag>droid-6.5</tag>
     </scm>
 
     <build>
@@ -49,7 +47,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.5-SNAPSHOT</version>
+                        <version>6.5</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -85,17 +83,17 @@
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-core</artifactId>
-            <version>6.5-SNAPSHOT</version>
+            <version>6.5</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-core-interfaces</artifactId>
-            <version>6.5-SNAPSHOT</version>
+            <version>6.5</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-container</artifactId>
-            <version>6.5-SNAPSHOT</version>
+            <version>6.5</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5-SNAPSHOT</version>
+        <version>6.5</version>
         <relativePath>droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
+      <tag>droid-6.5</tag>
   </scm>
     
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.5</version>
+        <version>6.6-SNAPSHOT</version>
         <relativePath>droid-parent</relativePath>
     </parent>
   
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>droid-6.5</tag>
+      <tag>HEAD</tag>
   </scm>
     
     <modules>


### PR DESCRIPTION
fixed a series of issues preventing the preparation of the release of the project
- binaries changelog out of date
- documentation issues appearing only during release or when running `mvn javadoc:javadoc`, related to incorrect documentation (invalid tags, missing documentation, incorrect configuration when building on jdk 11 while jdk 8 is default)
- missing dependency