### PR TITLE
Update to shebang line

### DIFF
--- a/droid-binary/bin/droid.sh
+++ b/droid-binary/bin/droid.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
 # All rights reserved.


### PR DESCRIPTION
This change makes the .sh file work on Mac OSX Catalina and (though untested) should still work on other unix based distributions.