### PR TITLE
Bug fixes to remove duplicated lines and trim null character from zipEntry

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommand.java
@@ -35,6 +35,7 @@ import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FilenameUtils;
 
@@ -51,6 +52,11 @@ import uk.gov.nationalarchives.droid.report.interfaces.ReportSpec;
  */
 public class ListReportsCommand implements DroidCommand {
 
+    /**
+     * SINGLE QUOTE string to be used in messages.
+     */
+    public static final String SINGLE_QUOTE = "'";
+
     private PrintWriter printWriter;
     private ReportManager reportManager;
     
@@ -63,16 +69,16 @@ public class ListReportsCommand implements DroidCommand {
         if (reports.isEmpty()) {
             printWriter.println(I18N.getResource(I18N.NO_REPORTS_DEFINED));
         } else {
-            StringBuilder builder = new StringBuilder();
             for (ReportSpec report : reports) {
-                String reportDescription = String.format("\nReport:\t'%s'\n\tFormats:", report.getName());
+                StringBuilder builder = new StringBuilder();
+                String reportDescription = String.format("\nReport:\t'%s'\n\tFormats:\t", report.getName());
                 builder.append(reportDescription);
+
                 List<String> outputFormats = getReportOutputFormats(report);
-                for (String format : outputFormats) {
-                    builder.append("\t'");
-                    builder.append(format);
-                    builder.append("'");
+                if (outputFormats != null) {
+                    builder.append(outputFormats.stream().map(s -> SINGLE_QUOTE + s + SINGLE_QUOTE).collect(Collectors.joining("\t")));
                 }
+
                 builder.append("\t'Pdf'\t'DROID Report XML'");
                 printWriter.println(builder.toString());
             }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommand.java
@@ -69,8 +69,8 @@ public class ListReportsCommand implements DroidCommand {
         if (reports.isEmpty()) {
             printWriter.println(I18N.getResource(I18N.NO_REPORTS_DEFINED));
         } else {
+            StringBuilder builder = new StringBuilder();
             for (ReportSpec report : reports) {
-                StringBuilder builder = new StringBuilder();
                 String reportDescription = String.format("\nReport:\t'%s'\n\tFormats:\t", report.getName());
                 builder.append(reportDescription);
 
@@ -80,8 +80,9 @@ public class ListReportsCommand implements DroidCommand {
                 }
 
                 builder.append("\t'Pdf'\t'DROID Report XML'");
-                printWriter.println(builder.toString());
+                builder.append(System.lineSeparator());
             }
+            printWriter.println(builder.toString());
         }
     }
     

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommand.java
@@ -80,7 +80,7 @@ public class ListReportsCommand implements DroidCommand {
                 }
 
                 builder.append("\t'Pdf'\t'DROID Report XML'");
-                builder.append(System.lineSeparator());
+                builder.append("\n");
             }
             printWriter.println(builder.toString());
         }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/ListReportsCommandTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.gov.nationalarchives.droid.command.action;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.nationalarchives.droid.report.interfaces.ReportManager;
+import uk.gov.nationalarchives.droid.report.interfaces.ReportSpec;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ListReportsCommandTest {
+
+    @Test
+    public void shouldSendCorrectReportToThePrintWriter_WhenThereAreReportsDefined() throws CommandExecutionException {
+        ListReportsCommand command = new ListReportsCommand();
+        ReportManager mockManager = mock(ReportManager.class);
+        PrintWriter mockWriter = mock(PrintWriter.class);
+
+        ReportSpec spec1 = mock(ReportSpec.class);
+        ReportSpec spec2 = mock(ReportSpec.class);
+
+        when(spec1.getName()).thenReturn("Report name for spec 1");
+        when(spec2.getName()).thenReturn("Report name for spec 2");
+
+        when(mockManager.listReportSpecs()).thenReturn(Arrays.asList(spec1, spec2));
+
+        command.setReportManager(mockManager);
+        command.setPrintWriter(mockWriter);
+
+        command.execute();
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(mockWriter, times(1)).println(captor.capture());
+
+        assertEquals("\n" +
+                "Report:\t'Report name for spec 1'\n" +
+                "\tFormats:\t\t'Pdf'\t'DROID Report XML'\n" +
+                "\n" +
+                "Report:\t'Report name for spec 2'\n" +
+                "\tFormats:\t\t'Pdf'\t'DROID Report XML'\n", captor.getValue());
+    }
+}

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TrueZipArchiveHandler.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/archive/TrueZipArchiveHandler.java
@@ -295,6 +295,7 @@ public class TrueZipArchiveHandler implements ArchiveHandler {
             }
             
             // If there is a file, submit the file:
+            entryName = (entryName == null) ? null : entryName.trim();
             entryName = FilenameUtils.getName(entryName);
             if (!entryName.isEmpty()) {
                 submit(entry, entryName, parentName, zipFile, correlationId, originatorNodeId);


### PR DESCRIPTION
2 Changes in here for 2 small bugfixes 
1) #482 - The StringBuilder was not being reinitialised, hence with every report iteration it added more and more details and printed it all
2) #505 - DPP files have a trailing null character in the names, trimming that would help get away from the error. 