### PR TITLE
Updated to use Open HTML TO PDF and removed itextpdf due to

### DIFF
--- a/droid-help/src/main/resources/Web pages/Third-party components.html
+++ b/droid-help/src/main/resources/Web pages/Third-party components.html
@@ -376,6 +376,16 @@
       </tr>
       <tr>
         <td align="center" width="50%">
+          <a href="https://github.com/danfickle/openhtmltopdf">Open HTML TO PDF &amp; PDF Renderer</a>
+           <img src="../Images/Icon_External_Link.png">
+        </td>
+        <td align="center" width="50%">
+          <a href="http://www.gnu.org/copyleft/lesser.html">Lesser General Public License</a> <img
+          src="../Images/Icon_External_Link.png">
+        </td>
+      </tr>
+      <tr>
+        <td align="center" width="50%">
           <a href="https://truezip.dev.java.net/">TrueZip</a> <img src=
           "../Images/Icon_External_Link.png"> 
         </td>

--- a/droid-report/pom.xml
+++ b/droid-report/pom.xml
@@ -17,8 +17,12 @@
         <connection>scm:git:https://github.com/digital-preservation/droid.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/droid.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/droid.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <openhtml.version>1.0.10</openhtml.version>
+    </properties>
   
     <build>
         <plugins>
@@ -87,13 +91,9 @@
             <artifactId>xml-apis</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.xhtmlrenderer</groupId>
-            <artifactId>flying-saucer-pdf-itext5</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.itextpdf</groupId>
-            <artifactId>itextpdf</artifactId>
-            <version>5.5.13.2</version>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-pdfbox</artifactId>
+            <version>${openhtml.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportTransformerImpl.java
+++ b/droid-report/src/main/java/uk/gov/nationalarchives/droid/report/ReportTransformerImpl.java
@@ -54,9 +54,8 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xhtmlrenderer.pdf.ITextRenderer;
 
-import com.itextpdf.text.DocumentException;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 
 import uk.gov.nationalarchives.droid.core.interfaces.config.DroidGlobalConfig;
 import uk.gov.nationalarchives.droid.util.FileUtil;
@@ -163,12 +162,12 @@ public class ReportTransformerImpl implements ReportTransformer {
 
             try (final Writer buffer = Files.newBufferedWriter(tmpXhtml, UTF_8))  {
                 transformUsingXsl(in, transformLocation, buffer);
-                
-                final ITextRenderer renderer = new ITextRenderer();
-                renderer.setDocument(tmpXhtml.toFile());
-                renderer.layout();
-                renderer.createPDF(out);
-            } catch (TransformerException | DocumentException e) {
+
+                final PdfRendererBuilder renderer = new PdfRendererBuilder();
+                renderer.withFile(tmpXhtml.toFile());
+                renderer.toStream(out);
+                renderer.run();
+            } catch (TransformerException | IOException e) {
                 throw new ReportTransformException(e);
             } finally {
                 FileUtil.deleteQuietly(tmpXhtml);


### PR DESCRIPTION
vulnerability (CVE-2021-43113) (#675)