### PR TITLE
Switch to SemVer 2.0.0 versioning scheme

### DIFF
--- a/droid-binary/pom.xml
+++ b/droid-binary/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
   

--- a/droid-build-tools/pom.xml
+++ b/droid-build-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   

--- a/droid-command-line/pom.xml
+++ b/droid-command-line/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-container/pom.xml
+++ b/droid-container/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-core/pom.xml
+++ b/droid-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-export-interfaces/pom.xml
+++ b/droid-export-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
    <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-export/pom.xml
+++ b/droid-export/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-help/pom.xml
+++ b/droid-help/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
   	    <relativePath>../droid-parent</relativePath>
     </parent>
  

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -11,7 +11,7 @@
   
     <groupId>uk.gov.nationalarchives</groupId>
     <artifactId>droid-parent</artifactId>
-    <version>6.6-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
   
     <name>droid-parent</name>

--- a/droid-report-interfaces/pom.xml
+++ b/droid-report-interfaces/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
         
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-report/pom.xml
+++ b/droid-report/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
     
@@ -50,7 +50,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>droid-parent</artifactId>
 		<groupId>uk.gov.nationalarchives</groupId>
-		<version>6.6-SNAPSHOT</version>
+		<version>6.6.0-SNAPSHOT</version>
 		<relativePath>../droid-parent</relativePath>
 	</parent>
 
@@ -90,7 +90,7 @@
 					<dependency>
 						<groupId>uk.gov.nationalarchives</groupId>
 						<artifactId>droid-build-tools</artifactId>
-						<version>6.6-SNAPSHOT</version>
+						<version>${project.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/droid-swing-ui/pom.xml
+++ b/droid-swing-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
   
@@ -46,7 +46,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/droid-tools/pom.xml
+++ b/droid-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../droid-parent</relativePath>
     </parent>
 
@@ -47,7 +47,7 @@
                     <dependency>
                         <groupId>uk.gov.nationalarchives</groupId>
                         <artifactId>droid-build-tools</artifactId>
-                        <version>6.6-SNAPSHOT</version>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -83,17 +83,17 @@
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-core</artifactId>
-            <version>6.6-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-core-interfaces</artifactId>
-            <version>6.6-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
             <artifactId>droid-container</artifactId>
-            <version>6.6-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>droid-parent</artifactId>
         <groupId>uk.gov.nationalarchives</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>droid-parent</relativePath>
     </parent>
   


### PR DESCRIPTION
Switch to using Semantic Versioning - https://semver.org/
The vast majority of Java projects follow the Semantic Versioning Scheme these days