### PR TITLE
Introduced suppressions for the vulnerabilities related to spring

### DIFF
--- a/dependency-check/suppressions.xml
+++ b/dependency-check/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>
+

--- a/droid-binary/dependency-check/suppressions.xml
+++ b/droid-binary/dependency-check/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-core-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-tx-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-aop-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-jdbc-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-context-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-expression-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>
+

--- a/droid-build-tools/dependency-check/suppressions.xml
+++ b/droid-build-tools/dependency-check/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>
+

--- a/droid-command-line/dependency-check/suppressions.xml
+++ b/droid-command-line/dependency-check/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-core-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-tx-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-aop-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-jdbc-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-context-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-expression-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>
+

--- a/droid-container/dependency-check/suppressions.xml
+++ b/droid-container/dependency-check/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>
+

--- a/droid-core-interfaces/dependency-check/suppressions.xml
+++ b/droid-core-interfaces/dependency-check/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>
+

--- a/droid-core/dependency-check/suppressions.xml
+++ b/droid-core/dependency-check/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>
+

--- a/droid-export-interfaces/dependency-check/suppressions.xml
+++ b/droid-export-interfaces/dependency-check/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>
+

--- a/droid-export/dependency-check/suppressions.xml
+++ b/droid-export/dependency-check/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-core-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-tx-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-aop-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-jdbc-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-context-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-expression-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>
+

--- a/droid-help/dependency-check/suppressions.xml
+++ b/droid-help/dependency-check/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>
+

--- a/droid-parent/dependency-check/suppressions.xml
+++ b/droid-parent/dependency-check/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-core-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-tx-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-aop-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-jdbc-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-context-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-expression-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>
+

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -89,7 +89,7 @@
 
         <project.email>pronom@nationalarchives.gov.uk</project.email>
 
-        <spring.version>5.3.19</spring.version>
+        <spring.version>5.3.20</spring.version>
         <hibernate.version>5.4.1.Final</hibernate.version>
         <derby.version>10.13.1.1</derby.version>
         <cxf.version>3.5.2</cxf.version>
@@ -295,6 +295,7 @@
                 <version>7.1.0</version>
                 <configuration>
                     <failBuildOnCVSS>8</failBuildOnCVSS>
+                    <suppressionFile>${project.basedir}/dependency-check/suppressions.xml</suppressionFile>
                 </configuration>
                 <executions>
                     <execution>
@@ -350,6 +351,7 @@
                         <exclude>*.db</exclude>
                         <exclude>*.GIF</exclude>
                         <exclude>*.PNG</exclude>
+                        <exclude>**/suppressions.xml</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/droid-report-interfaces/dependency-check/suppressions.xml
+++ b/droid-report-interfaces/dependency-check/suppressions.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-core-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-tx-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-aop-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-jdbc-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-context-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-expression-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>

--- a/droid-report/dependency-check/suppressions.xml
+++ b/droid-report/dependency-check/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-core-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-tx-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-aop-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-jdbc-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-context-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-expression-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>
+

--- a/droid-results/dependency-check/suppressions.xml
+++ b/droid-results/dependency-check/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-core-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-tx-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-aop-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-jdbc-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-context-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-expression-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>
+

--- a/droid-swing-ui/dependency-check/suppressions.xml
+++ b/droid-swing-ui/dependency-check/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-core-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-tx-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-aop-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-jdbc-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-beans-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-context-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress until="2022-10-01Z">
+        <notes><![CDATA[
+   file name: spring-expression-5.3.20.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>
+

--- a/droid-tools/dependency-check/suppressions.xml
+++ b/droid-tools/dependency-check/suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>
+

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
                         <exclude>appveyor.yml</exclude>
                         <exclude>.gitattributes</exclude>
                         <exclude>.github/**</exclude>
+                        <exclude>**/suppressions.xml</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Introduced suppressions for the vulnerabilities related to spring to get the build succeeding again.

The droid build started failing on the spring framework vulnerability 
spring-core-5.3.20.jar: CVE-2016-1000027
spring-tx-5.3.20.jar: CVE-2016-1000027

Basically, this vulnerability has been identified long time back. A recent change in the nist database meant the database now sees v5.3.20 as vulnerable. 
https://nvd.nist.gov/vuln/detail/CVE-2016-1000027#VulnChangeHistorySection


See interesting details about the vulnerability here: https://docs.spring.io/spring-framework/docs/current/reference/html/integration.html#remoting-httpinvoker

As a result, I have introduced suppressions of checking for this particular entry until 1st October to get a successful build. 
