### PR TITLE
FIXES: Any ?? matcher should not be part of sequences.

### DIFF
--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceSerializer.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceSerializer.java
@@ -179,6 +179,7 @@ public final class ByteSequenceSerializer {
 
     /**
      * Rewrites a PRONOM expression with the syntax selected.
+     * Assumes we are anchored to the BOF.  Use the other method if you want to supply the anchor type too.
      *
      * @param expression The PRONOM expression to rewrite.
      * @param sigType Whether the syntax should target binary or container signature syntax.
@@ -187,7 +188,23 @@ public final class ByteSequenceSerializer {
      * @throws CompileException If anything goes wrong during the compilation.
      */
     public String toPRONOMExpression(String expression, SignatureType sigType, boolean spaceElements) throws CompileException {
+        //TODO: assumption that it's always anchored to BOFOffset.  Hanging wildcards result in different outputs if it's anchored to BOF or EOF.
         return toPRONOMExpression(ByteSequenceCompiler.COMPILER.compile(expression), sigType, spaceElements);
+    }
+
+    /**
+     * Rewrites a PRONOM expression with the syntax selected.
+     *
+     * @param expression The PRONOM expression to rewrite.
+     * @param sigType Whether the syntax should target binary or container signature syntax.
+     * @param anchorType Whether the expression is anchored to the BOF, EOF, or is Variable.
+     * @param spaceElements Whether elements in the expression should have whitespace between them.
+     * @return A PRONOM expression with the syntax selected
+     * @throws CompileException If anything goes wrong during the compilation.
+     */
+    public String toPRONOMExpression(String expression, SignatureType sigType, ByteSequenceAnchor anchorType, boolean spaceElements) throws CompileException {
+        //TODO: assumption that it's always anchored to BOFOffset.  Hanging wildcards result in different outputs if it's anchored to BOF or EOF.
+        return toPRONOMExpression(ByteSequenceCompiler.COMPILER.compile(expression, anchorType), sigType, spaceElements);
     }
 
     /**
@@ -346,7 +363,12 @@ public final class ByteSequenceSerializer {
                 break;
             }
             case REPEAT: { // repeats only get used for fixed gaps in droid expressions, e.g. {5}
-                builder.append('{').append(tree.getChild(0).getIntValue()).append('}');
+                int repeatNum = tree.getChild(0).getIntValue();
+                if (repeatNum == 1) {
+                    builder.append("??");
+                } else {
+                    builder.append('{').append(repeatNum).append('}');
+                }
                 break;
             }
             case REPEAT_MIN_TO_MANY: {

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceCompilerTest.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/signature/compiler/ByteSequenceCompilerTest.java
@@ -332,11 +332,10 @@ public class ByteSequenceCompilerTest {
         }
     }
 
-    @Test
+    @Test(expected=CompileException.class)
     public void testAny() throws Exception {
         ByteSequence seq = COMPILER.compile("??");
         SubSequence sub  = assertSingleSubSequenceNoFragments(seq);
-        assertSingleByteMatcher(sub.getAnchorMatcher(), AnyByteMatcher.class);
     }
 
     @Test
@@ -502,8 +501,7 @@ public class ByteSequenceCompilerTest {
     @Test
     public void testAllowAllAnchorStrategy() throws Exception {
         testCompile(DROID, "[&01]", "[&01]", 0, 0);
-        testCompile(DROID, "??", ".", 0, 0);
-        testCompile(DROID, "?? [00:F9] ?? [&01]", ". [00-F9] . [&01]", 0, 0);
+        testCompile(DROID, "[&01][&01][&01][&01]", "[&01][&01][&01][&01]", 0, 0);
     }
 
     /*******************************************************************************************************************

--- a/droid-tools/src/main/java/uk/gov/nationalarchives/droid/tools/SigTool.java
+++ b/droid-tools/src/main/java/uk/gov/nationalarchives/droid/tools/SigTool.java
@@ -180,7 +180,7 @@ public final class SigTool {
                 if (cli.hasOption(MATCH_OPTION)) {
                     matchFiles(cli, output, anchorType);
                 } else if (cli.hasOption(EXPRESSION_OUTPUT)) {
-                    SigUtils.convertExpressionSyntax(output, cli.getArgList(), sigType, spaceElements, noTabs);
+                    SigUtils.convertExpressionSyntax(output, cli.getArgList(), sigType, anchorType, spaceElements, noTabs);
                 } else {
                     SigUtils.convertExpressionsToXML(output, cli.getArgList(), compileType, sigType, anchorType, noTabs);
                 }

--- a/droid-tools/src/main/java/uk/gov/nationalarchives/droid/tools/SigUtils.java
+++ b/droid-tools/src/main/java/uk/gov/nationalarchives/droid/tools/SigUtils.java
@@ -418,15 +418,16 @@ public final class SigUtils {
      * @param output The PrintStream to write the new expression to.
      * @param expressions A list of expressions to convert.
      * @param sigType Whether the expressions should be in BINARY or CONTAINER syntax.
+     * @param anchorType whether a signature is anchored to the BOF or EOF of a file.
      * @param spaceElements Whether to space syntactic elements for greater readability.
      * @param noTabs If notabs is set, just the compiled expressions are output, without the original expression or tabs.
      * @throws CompileException If there is a problem compiling the expression.
      */
     public static void convertExpressionSyntax(PrintStream output, List<String> expressions, SignatureType sigType,
-                                               boolean spaceElements, boolean noTabs) throws CompileException {
+                                               ByteSequenceAnchor anchorType, boolean spaceElements, boolean noTabs) throws CompileException {
         // anything not an option are the expressions to process.
         for (String expression : expressions) {
-            String xml = ByteSequenceSerializer.SERIALIZER.toPRONOMExpression(expression, sigType, spaceElements) ;
+            String xml = ByteSequenceSerializer.SERIALIZER.toPRONOMExpression(expression, sigType, anchorType, spaceElements) ;
             if (noTabs) {
                 output.println(xml);
             } else {


### PR DESCRIPTION
?? symbols were being incorrectly included as part of the XML signature text.  They should instead be modelled as min/max offsets between what precedes them and what follows them.  This fix removes the ANY (??) matcher as a valid part of an anchoring sequence, as that was incorrect.

The fix is to ensure that the ANY type is not processed as part of the anchor text, and cannot be included in fragment text either.  Finally, sigtool correctly takes account of the anchor type (BOF/EOF) when serializing signatures.

sigtool will now correctly process `-b -p "04??[01:0C][01:1F]{28}([41:5A]|[61:7A]){10}(43|44|46|4C|4E)"`, with the ?? turned into min/max offset of 1.