### PR TITLE
cater for possible blank space in launch path of droid on Windows

### DIFF
--- a/droid-binary/bin/droid.bat
+++ b/droid-binary/bin/droid.bat
@@ -141,7 +141,7 @@ IF "%1"=="" GOTO NOPARAM
 
 :PARAM
 REM Has command-line parameters -- run command-line version:
-${JRE_BIN_PATH}java %DROID_OPTIONS% -jar "%DROID_HOME%droid-command-line-${project.version}.jar" %*
+"${JRE_BIN_PATH}java" %DROID_OPTIONS% -jar "%DROID_HOME%droid-command-line-${project.version}.jar" %*
 
 GOTO end
 


### PR DESCRIPTION
Enclosed the launch path in double quotes so that the batch file can launch even if the path has a space in it