### PR TITLE
issue-898 path separator slashes to work as per OS

### DIFF
--- a/droid-binary/pom.xml
+++ b/droid-binary/pom.xml
@@ -35,7 +35,7 @@
                         </goals>
                         <configuration>
                             <!-- To update, retrieve link for windows jdk on x86 architecture from https://adoptium.net -->
-                            <url>https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.16.1_1.zip</url>
+                            <url>https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.18%2B10/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.18_10.zip</url>
                             <unpack>false</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
@@ -56,10 +56,9 @@
                         <configuration>
                             <tasks>
                                 <!-- Update binary from https://adoptopenjdk.net/releases.html -->
-                                <unzip src="${project.build.directory}/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.16.1_1.zip" dest="${project.build.directory}/jre_tmp/" />
-
+                                <unzip src="${project.build.directory}/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.18_10.zip" dest="${project.build.directory}/jre_tmp/" />
                                 <move todir="${project.build.directory}/jre-windows/">
-                                    <fileset dir="${project.build.directory}/jre_tmp/jdk-11.0.16.1+1-jre/">
+                                    <fileset dir="${project.build.directory}/jre_tmp/jdk-11.0.18+10-jre/">
                                         <include name="**/*" />
                                     </fileset>
                                 </move>

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
@@ -274,30 +274,6 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
         return result;
     }
 
-/*
-        if (uri == null)
-            return ;
-        if ("file".equals(uri.getScheme()))
-            return Paths.get(uri).toAbsolutePath().toString();
-
-        String result = java.net.URLDecoder.decode(uri.toString()).replaceAll("file://", "");
-
-        // Handle substitution of 7z
-        final String sevenZedIdentifier = "sevenz:";
-        if (result.startsWith(sevenZedIdentifier))
-            result = "7z:" + result.substring(sevenZedIdentifier.length());
-
-        // Handle substitution of gz
-        final String gzIdentifier = "gz:";
-        if (result.startsWith(gzIdentifier))
-            result = "gzip:" + result.substring(gzIdentifier.length());
-
-        return result;
-
- */
-
-
-
     /**
      * No config is needed by this class, but it's retained temporarily for backwards compatibility purposes.
      * @param config the config to set

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
@@ -46,7 +46,10 @@ import uk.gov.nationalarchives.droid.export.interfaces.ExportOptions;
 import uk.gov.nationalarchives.droid.export.interfaces.ItemWriter;
 import uk.gov.nationalarchives.droid.profile.referencedata.Format;
 
+import java.io.File;
 import java.io.Writer;
+import java.net.URI;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -85,6 +88,8 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
             "FORMAT_NAME",
             "FORMAT_VERSION",
     };
+
+    private static final String FILE_URI_SCHEME = "file";
 
     /*
      * Indexes of the headers used in the CSV output.
@@ -246,7 +251,53 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
     private static String toFileName(String name) {
         return FilenameUtils.getName(name);
     }
-    
+
+    private String toFilePath(URI uri) {
+        if (uri == null) {
+            log.warn("[URI not set]");
+            return "";
+        }
+        if (FILE_URI_SCHEME.equals(uri.getScheme())) {
+            return Paths.get(uri).toAbsolutePath().toString();
+        }
+
+        // for URIs that have other than "file" scheme
+        String result = java.net.URLDecoder.decode(uri.toString()).replaceAll("file://", "");
+        result = result.replace("/", File.separator);
+
+        // Handle substitution of 7z
+        final String sevenZedIdentifier = "sevenz:";
+        if (result.startsWith(sevenZedIdentifier)) {
+            result = "7z:" + result.substring(sevenZedIdentifier.length());
+        }
+
+        return result;
+    }
+
+/*
+        if (uri == null)
+            return ;
+        if ("file".equals(uri.getScheme()))
+            return Paths.get(uri).toAbsolutePath().toString();
+
+        String result = java.net.URLDecoder.decode(uri.toString()).replaceAll("file://", "");
+
+        // Handle substitution of 7z
+        final String sevenZedIdentifier = "sevenz:";
+        if (result.startsWith(sevenZedIdentifier))
+            result = "7z:" + result.substring(sevenZedIdentifier.length());
+
+        // Handle substitution of gz
+        final String gzIdentifier = "gz:";
+        if (result.startsWith(gzIdentifier))
+            result = "gzip:" + result.substring(gzIdentifier.length());
+
+        return result;
+
+ */
+
+
+
     /**
      * No config is needed by this class, but it's retained temporarily for backwards compatibility purposes.
      * @param config the config to set
@@ -344,7 +395,7 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
         addColumn(row, ID_ARRAY_INDEX, nullSafeNumber(node.getId()));
         addColumn(row, PARENT_ID_ARRAY_INDEX, nullSafeNumber(node.getParentId()));
         addColumn(row, URI_ARRAY_INDEX, DroidUrlFormat.format(node.getUri()));
-        addColumn(row, FILE_PATH_ARRAY_INDEX, node.toString());
+        addColumn(row, FILE_PATH_ARRAY_INDEX, toFilePath(node.getUri()));
         addColumn(row, FILE_NAME_ARRAY_INDEX, toFileName(metaData.getName()));
         addColumn(row, ID_METHOD_ARRAY_INDEX, nullSafeName(metaData.getIdentificationMethod()));
         addColumn(row, STATUS_ARRAY_INDEX, metaData.getNodeStatus().getStatus());

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNode.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ProfileResourceNode.java
@@ -31,17 +31,15 @@
  */
 package uk.gov.nationalarchives.droid.profile;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import uk.gov.nationalarchives.droid.profile.referencedata.Format;
+
 import java.net.URI;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-
-import uk.gov.nationalarchives.droid.profile.referencedata.Format;
 
 /**
 * @author rflitcroft, mpalmer
@@ -191,26 +189,10 @@ public class ProfileResourceNode {
      * {@inheritDoc}
      */
     @Override
-    public String toString()
-    {
-        if (uri == null) {
-            return "[URI not set]";
-        }
-
-        if ("file".equals(uri.getScheme())) {
-            return Paths.get(uri).toAbsolutePath().toString();
-        }
-
-        String result = java.net.URLDecoder.decode(uri.toString()).replaceAll("file://", "");
-
-        // Handle substitution of 7z
-        final String sevenZedIdentifier = "sevenz:";
-        if (result.startsWith(sevenZedIdentifier)) {
-            result = "7z:" + result.substring(sevenZedIdentifier.length());
-        }
-
-        return result;
+    public String toString() {
+        return uri == null ? "[URI not set]" : java.net.URLDecoder.decode(uri.toString());
     }
+
 
     /**
      * @return prefix Getter method for prefix.

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/config/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/config/Bundle.properties
@@ -112,4 +112,4 @@ ConfigDialog.containerSigFileLabel.text_1=Container Signature File
 ConfigDialog.processArcCheckBox.text=arc
 ConfigDialog.processWarcCheckBox.text=warc
 ConfigDialog.toggleWebArchivesButton.text=Check / Uncheck all
-ConfigDialog.webArchivesLabel.text=Analyse contents of archive files
+ConfigDialog.webArchivesLabel.text=Analyse contents of web archive files


### PR DESCRIPTION
This PR has 3 fixes 
1) The slashes on windows in the no profile output were forward slashes, it is now changed to backslashes as consistent with 6.5.2
2) Bundled JRE is updated to the newer minor version.
3) A small issue related to terminology used on the preferences dialog is fixed to make the two options clearer