### PR TITLE
removed uploading to github as it does it for all combinations of OS …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,3 @@ jobs:
         run: mvn -V -B -DskipTests=true install
       - name: Maven Test
         run: mvn -B verify
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: droid-binary
-          path: ./droid-binary/target/*.zip
-          if-no-files-found: error
-          retention-days: 2


### PR DESCRIPTION
…and java versions

Basically, we end up with 9 CI builds all writing the same name one over other, this is also unnecessary as we now have a snapshot build and upload running on local CI server. 