### PR TITLE
For GUI and profile, moved the header writing closer to data writing …

### DIFF
--- a/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/ExportTask.java
+++ b/droid-export/src/main/java/uk/gov/nationalarchives/droid/export/ExportTask.java
@@ -188,8 +188,8 @@ public class ExportTask implements Runnable {
 
         //BNO - amended to add header customisations for different hash algorithms
         Map<String, String> headerCustomisations = getHeaderCustomisationsFromProfiles();
-        itemWriter.setHeaders(headerCustomisations);
         itemWriter.setOptions(options);
+        itemWriter.setHeaders(headerCustomisations);
         itemWriter.open(writer);
         
         StopWatch stopWatch = new StopWatch();

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
@@ -184,6 +184,9 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
                 break;
             }
             default: {
+                //what? unknown option
+                log.warn("Unable to handle ExportOptions = " + options + ", was there a new option created?");
+                options = ExportOptions.ONE_ROW_PER_FILE;
                 writeOneRowPerFile(nodes);
             }
         }

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
@@ -191,7 +191,7 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
     
     private void writeOneRowPerFile(List<? extends ProfileResourceNode> nodes) {
         if (csvWriter.getRecordCount() == 0) {
-            writeHeadersForOneLinePerFileExport(nodes);
+            writeHeadersForOneRowPerFileExport(nodes);
         }
         try {
             for (ProfileResourceNode node : nodes) {
@@ -258,7 +258,7 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
         }
     }
 
-    private void writeHeadersForOneLinePerFileExport(List<? extends ProfileResourceNode> nodes) {
+    private void writeHeadersForOneRowPerFileExport(List<? extends ProfileResourceNode> nodes) {
 
         if (options != ExportOptions.ONE_ROW_PER_FILE) {
             throw new RuntimeException("Unexpectedly called per file header creation. Unable to proceed");
@@ -278,17 +278,10 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
             if (maxIdentifications > 1) { //add headers
                 for (int newColumnSuffix = 2; newColumnSuffix <= maxIdentifications; newColumnSuffix++) {
                     //"PUID","MIME_TYPE","FORMAT_NAME","FORMAT_VERSION"
-                    if (headersToWrite.contains(HEADER_NAME_PUID)) {
-                        headersToWrite.add(HEADER_NAME_PUID + newColumnSuffix);
-                    }
-                    if (headersToWrite.contains(HEADER_NAME_MIME_TYPE)) {
-                        headersToWrite.add(HEADER_NAME_MIME_TYPE + newColumnSuffix);
-                    }
-                    if (headersToWrite.contains(HEADER_NAME_FORMAT_NAME)) {
-                        headersToWrite.add(HEADER_NAME_FORMAT_NAME + newColumnSuffix);
-                    }
-                    if (headersToWrite.contains(HEADER_NAME_FORMAT_VERSION)) {
-                        headersToWrite.add(HEADER_NAME_FORMAT_VERSION + newColumnSuffix);
+                    for (String headerEntry : PER_FORMAT_HEADERS) {
+                        if (headersToWrite.contains(headerEntry)) {
+                            headersToWrite.add(headerEntry + newColumnSuffix);
+                        }
                     }
                 }
             }

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/CsvItemWriter.java
@@ -191,7 +191,7 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
     
     private void writeOneRowPerFile(List<? extends ProfileResourceNode> nodes) {
         if (csvWriter.getRecordCount() == 0) {
-            writeHeadersForOneLinePerFormatExport(nodes);
+            writeHeadersForOneLinePerFileExport(nodes);
         }
         try {
             for (ProfileResourceNode node : nodes) {
@@ -258,9 +258,9 @@ public class CsvItemWriter implements ItemWriter<ProfileResourceNode> {
         }
     }
 
-    private void writeHeadersForOneLinePerFormatExport(List<? extends ProfileResourceNode> nodes) {
+    private void writeHeadersForOneLinePerFileExport(List<? extends ProfileResourceNode> nodes) {
 
-        if (options == ExportOptions.ONE_ROW_PER_FORMAT) {
+        if (options != ExportOptions.ONE_ROW_PER_FILE) {
             throw new RuntimeException("Unexpectedly called per file header creation. Unable to proceed");
         }
 

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/CsvItemWriterTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/CsvItemWriterTest.java
@@ -76,8 +76,8 @@ import static org.mockito.Mockito.when;
  */
 public class CsvItemWriterTest {
 
-	private static DateTime testDateTime = new DateTime(12345678L);
-	private static final String LINE_SEPARATOR = "\n";
+    private static final DateTime testDateTime = new DateTime(12345678L);
+    private static final String LINE_SEPARATOR = "\n";
     private CsvItemWriter itemWriter;
     private File destination;
     private DroidGlobalConfig config;
@@ -100,22 +100,6 @@ public class CsvItemWriterTest {
     @After
     public void tearDown() {
         itemWriter.close();
-    }
-
-    @Test
-    public void testWriteHeadersOnOpen() throws IOException {
-        try(final Writer writer = new StringWriter()) {
-            JobOptions jobOptions = mock(JobOptions.class);
-            when(jobOptions.getParameter("location")).thenReturn("test.csv");
-
-            // String hashAlgorithm = config.getProperties().getProperty("HASH_ALGORITHM").toString();
-            //when(config.getBooleanProperty(DroidGlobalProperty\.CSV_EXPORT_ROW_PER_FORMAT)).thenReturn(false);
-            itemWriter.setOptions(ExportOptions.ONE_ROW_PER_FORMAT);
-            itemWriter.open(writer);
-            final String expectedString = toCsvRow(CsvItemWriter.HEADERS) + LINE_SEPARATOR;
-
-            assertEquals(writer.toString(), expectedString);
-        }
     }
 
     private static String toCsvRow(final String[] values) {
@@ -261,7 +245,7 @@ public class CsvItemWriterTest {
     }
 
     @Test
-    public void testWriteOneNodeWithTwoFormatsWithOneRowPerFile() throws IOException {
+    public void shouldCreateAdditionalHeadersForIdentificationFormatsWhenWritingAnEntryPerFile() throws IOException {
         when(config.getBooleanProperty(DroidGlobalProperty.CSV_EXPORT_ROW_PER_FORMAT)).thenReturn(false);
 
         try(final Writer writer = new StringWriter()) {
@@ -278,6 +262,12 @@ public class CsvItemWriterTest {
             itemWriter.setOptions(ExportOptions.ONE_ROW_PER_FILE);
             itemWriter.open(writer);
             itemWriter.write(nodes);
+
+            final String expectedHeaders = toCsvRow(new String[] {
+                    "ID","PARENT_ID","URI","FILE_PATH","NAME","METHOD","STATUS","SIZE","TYPE","EXT","LAST_MODIFIED","EXTENSION_MISMATCH","HASH","FORMAT_COUNT",
+                    "PUID","MIME_TYPE","FORMAT_NAME","FORMAT_VERSION", //per format columns
+                    "PUID2","MIME_TYPE2","FORMAT_NAME2","FORMAT_VERSION2", //per format columns
+            });
 
             final String expectedEntry1 = toCsvRow(new String[] {
                     "", "",
@@ -306,6 +296,7 @@ public class CsvItemWriterTest {
             final String[] lines = writer.toString().split(LINE_SEPARATOR);
 
             assertEquals(2, lines.length);
+            assertEquals(expectedHeaders, lines[0]);
             assertEquals(expectedEntry1, lines[1]);
         }
     }
@@ -470,4 +461,3 @@ public class CsvItemWriterTest {
         return format;
     }
 }
-


### PR DESCRIPTION
…so that we can generate additional headers when exporting per file
(Merging to master rather than patch branch)

The main changes are

* Moved writing of headers closer to when the data is about to be written - hence the unit test for checking that the header writing happens in "open" has been removed
* Look through the data to see if we need to create additional headers "per format", if so, create those headers
* Do the additional headers ONLY if we are writing the records "one file per row"
* If a single row is written, do not attempt to write headers again, this is necessary for defence in the no-profile mode where the CSVWriter is invoked once per resource.