### PR TITLE
Changes to use embedded JRE for the Windows batch file

### DIFF
--- a/droid-binary/bin/sigtool.bat
+++ b/droid-binary/bin/sigtool.bat
@@ -1,2 +1,5 @@
 @echo off
-java -jar droid-tools-${project.version}.jar %*
+REM Infer DROID_HOME from script location
+SET DROID_HOME=%~dp0
+
+"${JRE_BIN_PATH}java" -jar droid-tools-${project.version}.jar %*


### PR DESCRIPTION
Just included the embedded JRE path for sigtool as well. 