### PR TITLE
Added new puids corresponding to iso in the archives map

### DIFF
--- a/droid-command-line/src/main/resources/archive-puids.properties
+++ b/droid-command-line/src/main/resources/archive-puids.properties
@@ -39,7 +39,7 @@ archive.arc=x-fmt/219, fmt/410
 archive.warc=fmt/289, fmt/1281, fmt/1355
 archive.bz=x-fmt/267, x-fmt/268
 archive.7z=fmt/484
-archive.iso=fmt/468
+archive.iso=fmt/468, fmt/1738, fmt/1739, fmt/1740, fmt/1741, fmt/1757
 archive.rar=x-fmt/264, fmt/411
 archive.fat=fmt/1087
 

--- a/droid-core-interfaces/src/main/resources/archive-puids.properties
+++ b/droid-core-interfaces/src/main/resources/archive-puids.properties
@@ -39,7 +39,7 @@ archive.arc=x-fmt/219, fmt/410
 archive.warc=fmt/289, fmt/1281, fmt/1355
 archive.bz=x-fmt/267, x-fmt/268
 archive.7z=fmt/484
-archive.iso=fmt/468
+archive.iso=fmt/468, fmt/1738, fmt/1739, fmt/1740, fmt/1741, fmt/1757
 archive.rar=x-fmt/264, fmt/411
 archive.fat=fmt/1087
 

--- a/droid-results/src/main/resources/archive-puids.properties
+++ b/droid-results/src/main/resources/archive-puids.properties
@@ -39,7 +39,7 @@ archive.arc=x-fmt/219, fmt/410
 archive.warc=fmt/289, fmt/1281, fmt/1355
 archive.bz=x-fmt/267, x-fmt/268
 archive.7z=fmt/484
-archive.iso=fmt/468
+archive.iso=fmt/468, fmt/1738, fmt/1739, fmt/1740, fmt/1741, fmt/1757
 archive.rar=x-fmt/264, fmt/411
 archive.fat=fmt/1087
 


### PR DESCRIPTION
A small PR to add PUIDs with ISO extension,that were newly added in v108, to the archives map.  