### PR TITLE
Made the arguments to -At and -Wt as optional

### DIFF
--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -409,15 +409,19 @@ public class CommandFactoryImpl implements CommandFactory {
 
     private void setExpandArchiveTypes(PropertiesConfiguration overrideProperties, String[] archiveTypes) {
         setAllArchivesExpand(overrideProperties, false);
-        for (String archiveType : archiveTypes) {
-            overrideProperties.setProperty(getArchivePropertyName(archiveType), true);
+        if (archiveTypes != null) {
+            for (String archiveType : archiveTypes) {
+                overrideProperties.setProperty(getArchivePropertyName(archiveType), true);
+            }
         }
     }
 
     private void setExpandWebArchiveTypes(PropertiesConfiguration overrideProperties, String[] webArchiveTypes) {
         setAllWebArchivesExpand(overrideProperties, false);
-        for (String archiveType : webArchiveTypes) {
-            overrideProperties.setProperty(getArchivePropertyName(archiveType), true);
+        if (webArchiveTypes != null) {
+            for (String archiveType : webArchiveTypes) {
+                overrideProperties.setProperty(getArchivePropertyName(archiveType), true);
+            }
         }
     }
 

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
@@ -94,7 +94,7 @@ public enum CommandLineParam {
      */
     PROFILE_PROPERTY("Pr", "profile-property", true, -1, I18N.PROFILE_PROPERTY_HELP, "profile property") {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) throws CommandLineException {
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
         }
     },
@@ -104,7 +104,7 @@ public enum CommandLineParam {
      */
     PROPERTY_FILE("Pf", "property-file", true, 1, I18N.PROPERTY_FILE_HELP, "property file") {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) throws CommandLineException {
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
         }
     },
@@ -152,8 +152,7 @@ public enum CommandLineParam {
     /** Add BOM to file parameter.   */
     BOM("B", "bom", I18N.EXPORT_WITH_BOM) {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory,
-                                       CommandLine cli) throws CommandLineException {
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
         }
     },
@@ -223,8 +222,7 @@ public enum CommandLineParam {
      */
     QUOTE_COMMAS("qc", "quote-commas", I18N.QUOTE_COMMAS_HELP) {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory,
-                                       CommandLine cli) throws CommandLineException {
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
         }
     },
@@ -234,8 +232,7 @@ public enum CommandLineParam {
      */
     COLUMNS_TO_WRITE("co", "columns", true, -1, I18N.COLUMNS_TO_WRITE_HELP, "columns-to-write") {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory,
-                                       CommandLine cli) throws CommandLineException {
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
         }
     },
@@ -245,8 +242,7 @@ public enum CommandLineParam {
      */
     ROW_PER_FORMAT("ri", "row-per-id", I18N.ROW_PER_IDENTIFICATION) {
         @Override
-        public DroidCommand getCommand(CommandFactory commandFactory,
-                CommandLine cli) throws CommandLineException {
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
         }
     },
@@ -301,7 +297,7 @@ public enum CommandLineParam {
         }
     },
     /** Open archive types. */
-    ARCHIVE_TYPES("At", "open-archive-types", true, -1, I18N.ARCHIVE_TYPES_HELP, "archive types") {
+    ARCHIVE_TYPES("At", "open-archive-types", false, -1, I18N.ARCHIVE_TYPES_HELP, "archive types") {
         @Override
         public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
@@ -315,7 +311,7 @@ public enum CommandLineParam {
         }
     },
     /** Open webarchive types. */
-    WEB_ARCHIVE_TYPES("Wt", "open-webarchive-types", true, 2, I18N.WEB_ARCHIVE_TYPES_HELP, "web archive types") {
+    WEB_ARCHIVE_TYPES("Wt", "open-webarchive-types", false, 2, I18N.WEB_ARCHIVE_TYPES_HELP, "web archive types") {
         @Override
         public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
             return null;
@@ -376,7 +372,7 @@ public enum CommandLineParam {
     /**
      * All the top-level command line options.
      */
-    public static final Map<String, CommandLineParam> TOP_LEVEL_COMMANDS = new HashMap<String, CommandLineParam>();
+    public static final Map<String, CommandLineParam> TOP_LEVEL_COMMANDS = new HashMap<>();
 
     static {
         addTopLevelCommand(HELP);
@@ -397,21 +393,21 @@ public enum CommandLineParam {
 
     private static final String FILENAME = "filename";
 
-    private String shortName;
-    private String longName;
-    private String resourceKey;
+    private final String shortName;
+    private final String longName;
+    private final String resourceKey;
     private boolean argsRequired;
     private int maxArgs;
     private String argName;
 
 
-    private CommandLineParam(String shortName, String longName, String resourceKey) {
+    CommandLineParam(String shortName, String longName, String resourceKey) {
         this.shortName = shortName;
         this.longName = longName;
         this.resourceKey = resourceKey;
     }
 
-    private CommandLineParam(String shortName, String longName, boolean argsRequired,
+    CommandLineParam(String shortName, String longName, boolean argsRequired,
                              int maxArgs, String resourceKey, String argName) {
         this(shortName, longName, resourceKey);
         this.maxArgs = maxArgs;

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryTest.java
@@ -1337,7 +1337,7 @@ public class CommandFactoryTest {
         List<String> propertyNames = getPropertyNames(e1.getProperties());
         assertEquals(13, propertyNames.size());
 
-        // -Only the 3 archives passed to -At should expand
+        // All archive types should be set to do not process
         assertFalse((boolean)e1.getProperties().getProperty("profile.processTar"));
         assertFalse((boolean)e1.getProperties().getProperty("profile.processZip"));
         assertFalse((boolean)e1.getProperties().getProperty("profile.processIso"));
@@ -1346,6 +1346,7 @@ public class CommandFactoryTest {
         assertFalse((boolean)e1.getProperties().getProperty("profile.process7zip"));
         assertFalse((boolean)e1.getProperties().getProperty("profile.processBzip2"));
 
+        //all web archives should be processed
         assertTrue((boolean)e1.getProperties().getProperty("profile.processArc"));
         assertTrue((boolean)e1.getProperties().getProperty("profile.processWarc"));
     }
@@ -1370,7 +1371,7 @@ public class CommandFactoryTest {
         List<String> propertyNames = getPropertyNames(e1.getProperties());
         assertEquals(13, propertyNames.size());
 
-        // -Only the 3 archives passed to -At should expand
+        //All archives should be processed
         assertTrue((boolean)e1.getProperties().getProperty("profile.processTar"));
         assertTrue((boolean)e1.getProperties().getProperty("profile.processZip"));
         assertTrue((boolean)e1.getProperties().getProperty("profile.processIso"));
@@ -1379,6 +1380,7 @@ public class CommandFactoryTest {
         assertTrue((boolean)e1.getProperties().getProperty("profile.process7zip"));
         assertTrue((boolean)e1.getProperties().getProperty("profile.processBzip2"));
 
+        //All web archives should be set to: do not process
         assertFalse((boolean)e1.getProperties().getProperty("profile.processArc"));
         assertFalse((boolean)e1.getProperties().getProperty("profile.processWarc"));
     }

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryTest.java
@@ -31,36 +31,29 @@
  */
 package uk.gov.nationalarchives.droid.command.action;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.URI;
-import java.nio.file.*;
-import java.util.*;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import org.springframework.context.annotation.Profile;
 import uk.gov.nationalarchives.droid.command.context.GlobalContext;
 import uk.gov.nationalarchives.droid.core.interfaces.ResourceType;
-import uk.gov.nationalarchives.droid.core.interfaces.config.DroidGlobalConfig;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionFieldEnum;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.CriterionOperator;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.Filter;
 import uk.gov.nationalarchives.droid.core.interfaces.filter.FilterCriterion;
 import uk.gov.nationalarchives.droid.export.interfaces.ExportOptions;
-import uk.gov.nationalarchives.droid.report.interfaces.ReportManager;
-import uk.gov.nationalarchives.droid.report.interfaces.ReportSpec;
-import uk.gov.nationalarchives.droid.report.interfaces.ReportSpecItem;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author rflitcroft
@@ -1320,6 +1313,72 @@ public class CommandFactoryTest {
         assertFalse((boolean)e1.getProperties().getProperty("profile.processRar"));
         assertFalse((boolean)e1.getProperties().getProperty("profile.process7zip"));
         assertFalse((boolean)e1.getProperties().getProperty("profile.processBzip2"));
+        assertFalse((boolean)e1.getProperties().getProperty("profile.processArc"));
+        assertFalse((boolean)e1.getProperties().getProperty("profile.processWarc"));
+    }
+
+    @Test
+    public void should_not_expand_any_archives_when_hyphen_At_flag_is_used_without_any_arguments() throws Exception {
+        when(context.getProfileRunCommand()).thenReturn(profileRunCommand);
+        String[] args = new String[] {
+                "-Nr",
+                "/home/user/Documents/test.doc",
+                "/home/user/Documents/test.xls",
+                "-W",
+                "-At"
+        };
+        CommandLine cli = parse(args);
+        ProfileRunCommand e1 = (ProfileRunCommand) factory.getNoProfileCommand(cli);
+
+        assertNotNull(e1);
+        assertFalse(e1.getRecursive());
+
+        assertEquals("stdout", e1.getDestination()); // output file not specified, so defaults to stdout.
+        List<String> propertyNames = getPropertyNames(e1.getProperties());
+        assertEquals(13, propertyNames.size());
+
+        // -Only the 3 archives passed to -At should expand
+        assertFalse((boolean)e1.getProperties().getProperty("profile.processTar"));
+        assertFalse((boolean)e1.getProperties().getProperty("profile.processZip"));
+        assertFalse((boolean)e1.getProperties().getProperty("profile.processIso"));
+        assertFalse((boolean)e1.getProperties().getProperty("profile.processGzip"));
+        assertFalse((boolean)e1.getProperties().getProperty("profile.processRar"));
+        assertFalse((boolean)e1.getProperties().getProperty("profile.process7zip"));
+        assertFalse((boolean)e1.getProperties().getProperty("profile.processBzip2"));
+
+        assertTrue((boolean)e1.getProperties().getProperty("profile.processArc"));
+        assertTrue((boolean)e1.getProperties().getProperty("profile.processWarc"));
+    }
+
+    @Test
+    public void should_not_expand_any_web_archives_when_hyphen_Wt_flag_is_used_without_any_arguments() throws Exception {
+        when(context.getProfileRunCommand()).thenReturn(profileRunCommand);
+        String[] args = new String[] {
+                "-Nr",
+                "/home/user/Documents/test.doc",
+                "/home/user/Documents/test.xls",
+                "-Wt",
+                "-A"
+        };
+        CommandLine cli = parse(args);
+        ProfileRunCommand e1 = (ProfileRunCommand) factory.getNoProfileCommand(cli);
+
+        assertNotNull(e1);
+        assertFalse(e1.getRecursive());
+
+        assertEquals("stdout", e1.getDestination()); // output file not specified, so defaults to stdout.
+        List<String> propertyNames = getPropertyNames(e1.getProperties());
+        assertEquals(13, propertyNames.size());
+
+        // -Only the 3 archives passed to -At should expand
+        assertTrue((boolean)e1.getProperties().getProperty("profile.processTar"));
+        assertTrue((boolean)e1.getProperties().getProperty("profile.processZip"));
+        assertTrue((boolean)e1.getProperties().getProperty("profile.processIso"));
+        assertTrue((boolean)e1.getProperties().getProperty("profile.processGzip"));
+        assertTrue((boolean)e1.getProperties().getProperty("profile.processRar"));
+        assertTrue((boolean)e1.getProperties().getProperty("profile.process7zip"));
+        assertTrue((boolean)e1.getProperties().getProperty("profile.processBzip2"));
+
         assertFalse((boolean)e1.getProperties().getProperty("profile.processArc"));
         assertFalse((boolean)e1.getProperties().getProperty("profile.processWarc"));
     }


### PR DESCRIPTION
The actual changes related to the ticket is 2 folds 
1) In `CommandLineParam`, the `ARCHIVE_TYPES` and `WEB_ARCHIVE_TYPES` have been changed to make their arguments optional
2)  In `CommandFactoryImpl` if there are no arguments passed to -At or -Wt, the property override is defensive against null

There are tests added for command line without the arguments.

All other changes are code cleanup identified as warnings. 