### PR TITLE
Issue 1011 format name difference between api and UI

### DIFF
--- a/droid-api/src/main/java/uk/gov/nationalarchives/droid/internal/api/DroidAPI.java
+++ b/droid-api/src/main/java/uk/gov/nationalarchives/droid/internal/api/DroidAPI.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang.StringUtils;
 import uk.gov.nationalarchives.droid.core.BinarySignatureIdentifier;
 import uk.gov.nationalarchives.droid.core.SignatureParseException;
 import uk.gov.nationalarchives.droid.core.interfaces.DroidCore;
+import uk.gov.nationalarchives.droid.core.interfaces.IdentificationMethod;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationResultCollection;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationResult;
 import uk.gov.nationalarchives.droid.core.interfaces.RequestIdentifier;
@@ -158,9 +159,18 @@ public final class DroidAPI {
             boolean fileExtensionMismatch = resultCollection.getExtensionMismatch();
 
             return resultCollection.getResults()
-                    .stream().map(res -> new ApiResult(extension, res.getMethod(), res.getPuid(), res.getName(), fileExtensionMismatch))
+                    .stream().map(res -> createApiResult(res, extension, fileExtensionMismatch))
                     .collect(Collectors.toList());
         }
+    }
+
+    private ApiResult createApiResult(IdentificationResult result, String extension, boolean extensionMismatch) {
+        String name = result.getName();
+        if (result.getMethod().equals(IdentificationMethod.CONTAINER)
+                && (droidCore.formatNameByPuid(result.getPuid()) != null)) {
+            name = droidCore.formatNameByPuid(result.getPuid());
+        }
+        return new ApiResult(extension, result.getMethod(), result.getPuid(), name, extensionMismatch);
     }
 
     private IdentificationResultCollection identifyByExtension(final FileSystemIdentificationRequest identificationRequest) {

--- a/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITest.java
+++ b/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITest.java
@@ -88,7 +88,7 @@ public class DroidAPITest {
         ApiResult identificationResult = results.get(0);
 
         assertThat(identificationResult.getPuid(), is("fmt/291"));
-        assertThat(identificationResult.getName(), is("Open Document Text 1.2"));
+        assertThat(identificationResult.getName(), is("OpenDocument Text"));
         assertThat(identificationResult.getMethod(), is(IdentificationMethod.CONTAINER));
     }
 
@@ -154,5 +154,12 @@ public class DroidAPITest {
             acc += results.size();
         }
         assertThat(acc, is(MAX_ITER));
+    }
+
+    @Test
+    public void should_identify_fmt_40_correctly_with_container_identification_method() throws IOException {
+        List<ApiResult> results = api.submit(
+                Paths.get("../droid-container/src/test/resources/word97.doc"));
+        assertThat(results.get(0).getName(), is("Microsoft Word Document"));
     }
 }

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/DroidCore.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/DroidCore.java
@@ -124,6 +124,11 @@ public interface DroidCore {
      * @param fileExtension The file extension to check against.
      */
     void checkForExtensionsMismatches(IdentificationResultCollection results, String fileExtension);
-    
-    
+
+    /**
+     * Returns name of the format based on puid from the signatures.
+     * @param puid string representation of puid
+     * @return format name
+     */
+    String formatNameByPuid(String puid);
 }

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/BinarySignatureIdentifier.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/BinarySignatureIdentifier.java
@@ -254,5 +254,15 @@ public class BinarySignatureIdentifier implements DroidCore {
             }
         }
     }
-   
+
+    /**
+     * Return the name of format based on the puid.
+     * @param puid
+     * @return format name
+     */
+    @Override
+    public String formatNameByPuid(String puid) {
+        FileFormat format = sigFile.getFileFormat(puid);
+        return format != null? format.getName() : null;
+    }
 }

--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/BinarySignatureIdentifier.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/BinarySignatureIdentifier.java
@@ -257,7 +257,7 @@ public class BinarySignatureIdentifier implements DroidCore {
 
     /**
      * Return the name of format based on the puid.
-     * @param puid
+     * @param puid puid whose corresponding format name is needed
      * @return format name
      */
     @Override


### PR DESCRIPTION
- Added a method on DroidCore
- In the API, if the identification method is "container", then get the format name based on puid from the signature
- Use that format name in the API result