### PR TITLE
UI minor bugs

### DIFF
--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
@@ -141,7 +141,6 @@ public class DroidMainFrame extends JFrame {
     private JFileChooser filterFileChooser;
     private ResourceSelectorDialog resourceFileChooser;
     private ButtonManager buttonManager;
-    private ConfigDialog configDialog;
     private GlobalContext globalContext;
     private JFileChooser exportFileChooser;
     private SignatureInstallDialog signatureInstallDialog;
@@ -320,7 +319,6 @@ public class DroidMainFrame extends JFrame {
 
         globalContext = new SpringGuiContext();
         profileManager = globalContext.getProfileManager();
-        configDialog = new ConfigDialog(this, globalContext);
         droidContext = new DroidUIContext(jProfilesTabbedPane, profileManager);
         exportFileChooser = new ExportFileChooser();
         filterFileChooser = new FilterFileChooser(globalContext.getGlobalConfig().getFilterDir().toFile());
@@ -1172,25 +1170,29 @@ public class DroidMainFrame extends JFrame {
     }// GEN-LAST:event_jMenuItemCopyFIlterToAllActionPerformed
 
     private void settingsMenuItemActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_settingsMenuItemActionPerformed
-        // initialise the dialog's values
+        // create the dialog and initialise the dialog's values
         Map<String, Object> settings = globalContext.getGlobalConfig().getPropertiesMap();
-        configDialog.init(settings);
 
-        configDialog.setVisible(true);
-        if (configDialog.getResponse() == ConfigDialog.OK) {
-            try {
-                globalContext.getGlobalConfig().update(configDialog.getGlobalConfig());
-            } catch (ConfigurationException e) {
-                log.error("Error updating properties: " + e.getMessage(), e);
-                JOptionPane.showMessageDialog(configDialog, NbBundle.getMessage(ConfigDialog.class,
-                        "ConfigDialog.error.text"),
-                        NbBundle.getMessage(ConfigDialog.class, "ConfigDialog.error.title"), JOptionPane.ERROR_MESSAGE);
-
+        ConfigDialog configDialog = new ConfigDialog(this, globalContext);
+        try {
+            configDialog.init(settings);
+            configDialog.setVisible(true);
+            if (configDialog.getResponse() == ConfigDialog.OK) {
+                try {
+                    globalContext.getGlobalConfig().update(configDialog.getGlobalConfig());
+                } catch (ConfigurationException e) {
+                    log.error("Error updating properties: " + e.getMessage(), e);
+                    JOptionPane.showMessageDialog(configDialog, NbBundle.getMessage(ConfigDialog.class,
+                                    "ConfigDialog.error.text"),
+                            NbBundle.getMessage(ConfigDialog.class, "ConfigDialog.error.title"), JOptionPane.ERROR_MESSAGE);
+                }
             }
-        }
 
-        if (configDialog.getCreateNewProfile()) {
-            createAndInitNewProfile();
+            if (configDialog.getCreateNewProfile()) {
+                createAndInitNewProfile();
+            }
+        } finally {
+            configDialog.dispose();
         }
     }// GEN-LAST:event_settingsMenuItemActionPerformed
 

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
@@ -907,7 +907,6 @@ public class ConfigDialog extends JDialog {
     }// </editor-fold>//GEN-END:initComponents
 
     private void okButtonActionPerformed(ActionEvent evt) {//GEN-FIRST:event_okButtonActionPerformed
-        response = OK;
         if (isDirtyForNewProfile()) {
             int optionResponse = JOptionPane.showOptionDialog(
                     this,
@@ -921,9 +920,11 @@ public class ConfigDialog extends JDialog {
             );
             switch (optionResponse) {
                 case JOptionPane.YES_OPTION:
+                    response = OK;
                     automaticallyCreateNewProfile = true;
                     break;
                 case JOptionPane.NO_OPTION:
+                    response = OK;
                     automaticallyCreateNewProfile = false;
                     break;
                 case JOptionPane.CANCEL_OPTION:
@@ -943,6 +944,7 @@ public class ConfigDialog extends JDialog {
     }
 
     private void cancelButtonActionPerformed(ActionEvent evt) {//GEN-FIRST:event_cancelButtonActionPerformed
+        response = CANCEL;
         dispose();
     }//GEN-LAST:event_cancelButtonActionPerformed
 

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/config/ConfigDialog.java
@@ -140,7 +140,7 @@ public class ConfigDialog extends JDialog {
 
     private void populatePropertyListNeedingNewProfile() {
         propertiesAffectingNewProfile.addAll(
-                Arrays.asList(DroidGlobalProperty.BINARY_UPDATE_URL.getName(), DroidGlobalProperty.CONTAINER_UPDATE_URL.getName(),
+                Arrays.asList(DroidGlobalProperty.DEFAULT_BINARY_SIG_FILE_VERSION.getName(), DroidGlobalProperty.DEFAULT_CONTAINER_SIG_FILE_VERSION.getName(),
                         DroidGlobalProperty.PROCESS_ZIP.getName(), DroidGlobalProperty.PROCESS_TAR.getName(),
                         DroidGlobalProperty.PROCESS_GZIP.getName(), DroidGlobalProperty.PROCESS_RAR.getName(),
                         DroidGlobalProperty.PROCESS_7ZIP.getName(), DroidGlobalProperty.PROCESS_ISO.getName(),


### PR DESCRIPTION
A few Ux bugs (some long standing, some recent) are fixed 
1) Cancelling the "Preferences" dialog was not resetting the changes on the dialog - this might have been a long standing source of confusion for many people around the issue of "hash not generated" 

2) Whether to launch a new profile or not is decided by a few properties, there should have been signature files in that list, instead there was signature file URL

3) Cancelling the "Do you want to create a new profile?" question and then cancelling the preferences dialog was still setting the response code to be OK causing another issue in a specific situation (might have been masked by 1 above) 