### PR TITLE
Export dialog minimum size reduced and tooltip made multiline

### DIFF
--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.form
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.form
@@ -11,11 +11,11 @@
     </Property>
     <Property name="alwaysOnTop" type="boolean" value="true"/>
     <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[1155, 835]"/>
+      <Dimension value="[730, 520]"/>
     </Property>
     <Property name="name" type="java.lang.String" value="exportDialog" noResource="true"/>
     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[1055, 760]"/>
+      <Dimension value="[730, 520]"/>
     </Property>
   </Properties>
   <SyntheticProperties>

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/export/ExportDialog.java
@@ -327,9 +327,9 @@ public class ExportDialog extends JDialog {
 
         setTitle(NbBundle.getMessage(ExportDialog.class, "ExportDialog.title_1")); // NOI18N
         setAlwaysOnTop(true);
-        setMinimumSize(new Dimension(1155, 835));
+        setMinimumSize(new Dimension(730, 520));
         setName("exportDialog"); // NOI18N
-        setPreferredSize(new Dimension(1055, 760));
+        setPreferredSize(new Dimension(730, 520));
 
         profileSelectLabel.setText(NbBundle.getMessage(ExportDialog.class, "ExportDialog.profileSelectLabel.text_1")); // NOI18N
 

--- a/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/export/Bundle.properties
+++ b/droid-swing-ui/src/main/resources/uk/gov/nationalarchives/droid/gui/export/Bundle.properties
@@ -73,4 +73,4 @@ ExportDialog.jButtonSetAllColumns.text=Set all columns
 ExportDialog.jButtonSetAllColumns.toolTipText=Sets all columns for export
 ExportDialog.jLabel2.text=Select an export template:
 ExportDialog.jCheckBoxUseTemplate.text=Use export template
-ExportDialog.jCheckBoxUseTemplate.toolTipText=If selected, you can choose a template configured in ".droid6/export_templates" folder. If not selected, you can choose columns.
+ExportDialog.jCheckBoxUseTemplate.toolTipText=<html>If selected, you can choose a template configured in ".droid6/export_templates" folder.<br> If not selected, you can choose one or more columns.</html>


### PR DESCRIPTION
1) Export dialog was too big for its contents 
2) The tooltip is wrapped into 2 lines so it is much more readable.