### PR TITLE
Improved the validation error messages on export template parsing

### DIFF
--- a/droid-help/src/main/resources/Web pages/Exporting profiles.html
+++ b/droid-help/src/main/resources/Web pages/Exporting profiles.html
@@ -105,195 +105,207 @@
       <img src="../Images/Export dialog.png">
     </p>
     <h2>
-       CSV File Columns
+      <a id="CSVColumns" name="CSVColumns">CSV File Columns</a>
     </h2>
-    <h3>
-       ID
-    </h3>
+
     <p>
-       This is a unique number assigned to each file, folder or archival file processed by DROID.
-    </p>
-    <h3>
-       <b>PARENT_ID</b>
-    </h3>
+      The following table describes the columns which can be exported from DROID.
     <p>
-       This is the id of the archival file or folder in which this file is contained.
+    <table style="border:1px solid #000" cellpadding="10">
+      <tr>
+        <th style="border:1px solid #000" bgcolor="#000000"><font color="#ffffff"/>Column Name</th>
+        <th style="border:1px solid #000" bgcolor="#000000"><font color="#ffffff"/>Description</th>
+        <th style="border:1px solid #000" bgcolor="#000000"><font color="#ffffff"/>Notes</th>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>ID</td>
+        <td>This is a unique number assigned to each file, folder or archival file processed by DROID.</td>
+        <td></td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>PARENT_ID</td>
+        <td>This is the id of the archival file or folder in which this file is contained.</td>
+        <td></td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>URI</td>
+        <td>Uniform Resource Identifier: This provides a standard, cross-platform way of describing where resources are located.
+          &nbsp;URIs are described in more detail in "<a href="Information collected by DROID.html#Location">Information collected by DROID</a></td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>FILE_PATH</td>
+        <td>The file system&nbsp;location of the resource being profiled, if the resource was directly
+          in a file system. &nbsp;Some files are not on the file system - for example, files inside a
+          zip file. In this case, the file paths are written relative to the parent file which
+          exists on the file system. Such paths also include the type of archive as a prefix.</td>
+        <td>file paths are platform dependent (they are different on Windows and unix).
+          &nbsp;DROID will write out file paths for the system on which it is currently running.
+          &nbsp;This means that if you profile files on a unix machine, then export the profiles on a
+          Windows machine, the file paths will be written out as if they were Windows file paths, and
+          vice versa.
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>NAME</td>
+        <td>The file name of the resource being profiled.</td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>METHOD</td>
+        <td>This field gives the method by which a resource identification has been made.</td>
+        <td >
+          Possible values:
+          <ul>
+            <li>
+              <b>Extension</b> - the file format was identified only by its filename <a href=
+                                                                                                "#Extension">extension</a>. &nbsp;This method may not be very reliable, as the filename
+              extension may be wrong. &nbsp;It is only used when DROID cannot identify a resource by
+              another method, and cannot usually identify what the version of a file format is, only its
+              broad type.
+            </li>
+            <li>
+              <b>Signature</b> - the file format was identified by finding a file format signature inside
+              the file itself. &nbsp;This method is more reliable than filename extensions, and can
+              identify the precise version of a file format.
+            </li>
+            <li>
+              <b>Container</b> - the file format was identified by finding embedded files and patterns
+              within them. &nbsp;This method is as reliable as signature identifications, and can be more
+              reliable.
+            </li>
+          </ul>
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>STATUS</td>
+        <td>This field gives the identification status of a resource.</td>
+        <td>
+          Possible values:
+          <ul>
+            <li>
+              <b>Not done</b> - the resource has not yet been profiled.
+            </li>
+            <li>
+              <b>Done</b> - the resource was processed with no errors.
+            </li>
+            <li>
+              <b>Access denied</b> - the operating system refused to give DROID read permissions to the
+              resource.
+            </li>
+            <li>
+              <b>Not found</b> - the resource was moved or deleted before DROID could read it.
+            </li>
+            <li>
+              <b>Error</b> - an error occurred while trying to profile a resource. &nbsp;For example, if
+              DROID is prevented from reading a file due to the user not having read permissions to it,
+              this will result in a profiling error for that file.
+            </li>
+          </ul>
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>SIZE</td>
+        <td>The size in bytes of a file.</td>
+        <td>Only files have a size, folders do not have a size. However, some files can contain other files inside them, for example zip files. In this case, the zip file has a size (as it is a file), and so do the files inside it. The size reported in all cases is the uncompressed size of each file, as it would appear if extracted from the container file.</td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>TYPE</td>
+        <td>The type of the resource</td>
+        <td>    <p>
+          DROID categorises the files and folders it profiles as being one of three types:
+        </p>
+          <ul>
+            <li>
+              <img src="../Images/fileResourceType.gif">
+              &nbsp;File&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </li>
+            <li>
+              <img src="../Images/folderResourceType.gif">
+              &nbsp;Folder&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            </li>
+            <li>
+              <img src="../Images/containerResourceType.gif"> &nbsp;Archival file&nbsp;(e.g. zip)
+            </li>
+          </ul>
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>EXT</td>
+        <td>The file extension of the resource</td>
+        <td>Extension is the last part of a filename following a full stop. Only files have extensions, as they indicate the type of the file. Even if a folder has a full stop in its name, it will not be assigned an extension.</td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>LAST_MODIFIED</td>
+        <td>The date and time on which a resource was last modified.</td>
+        <td></td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>EXTENSION_MISMATCH</td>
+        <td>Whether there is a mismatch between the extension of the resource and its identification by signature</td>
+        <td>
+          Possible values:
+          <ul>
+            <li>
+              <b>true</b> - the extension of the file is different from the expected extension as identified by DROID.
+            </li>
+            <li>
+              <b>false</b> - the extension of the file matches the expected extension as identified by DROID.
+            </li>
+          </ul>
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>HASH</td>
+        <td>Hash is a fixed-size string of characters that is generated by running the contents of a file through a mathematical algorithm. DROID supports MD%, SHA1, SHA256 and SHA512 algorithms</td>
+        <td>
+          If you have enabled <a href="Change preferences.html#GenerateHash">hash generation</a> in
+          the preferences, then this column will contain the MD5, SHA1, SHA256 or SHA512 hash for each file and archival file
+          processed. &nbsp;See "<a href="Detecting duplicate files.html">Detecting duplicate files</a>"
+          for more information on hashes.
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>FORMAT_COUNT</td>
+        <td>The number of identifications made to the resource.</td>
+        <td></td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>PUID</td>
+        <td>The PRONOM Unique Identifier of the resource, which identifies the format</td>
+        <td>
+          The&nbsp;PRONOM Unique IDentifier (PUID) identifies the precise file format of a profiled
+          file. When a resource has been identified, it is assigned a PUID. &nbsp;&nbsp;A unique
+          identifier exists for every file format that DROID can recognise, and these identifiers are
+          maintained in the <a href="http://www.nationalarchives.gov.uk/pronom">PRONOM</a><img src="../Images/Icon_External_Link.png">&nbsp;technical registry database, hosted at the UK National Archives.
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>MIME_TYPE</td>
+        <td>The mime type of the resource where known.</td>
+        <td>
+          The mime-type of an identified file format is a high level format identifier assigned by the
+          <a href="http://www.iana.org/assignments/media-types/">Internet Assigned Numbers</a><img src="../Images/Icon_External_Link.png">. &nbsp;It is widely used in email and other internet protocols to identify the type of resource. &nbsp;Not all file formats identified by DROID
+          have an assigned mime-type, and different <a href="#PUID">PUIDs</a> assigned by DROID can have the same mime-type
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>FORMAT_NAME</td>
+        <td>
+          The name of an identified&nbsp;file format, as listed in the <a href="http://www.nationalarchives.gov.uk/pronom">PRONOM</a>
+          <img src="../Images/Icon_External_Link.png">&nbsp;technical registry against its
+          <a href="#PUID">PUID</a>.
+        </td>
+      </tr>
+      <tr style="border-bottom: 1px solid #000">
+        <td>FORMAT_VERSION</td>
+        <td>
+          The version of an identified file format, as listed in the <a href="http://www.nationalarchives.gov.uk/pronom">PRONOM</a>
+          <img src="../Images/Icon_External_Link.png">&nbsp;technical registry against its <a href="#PUID">PUID</a>.
+          Not all file formats have a defined version, so this field can be blank even when a file has a PUID.
+        </td>
+      </tr>
+    </table>
     </p>
-    <h3>
-       URI (Uniform Resource Identifier)
-    </h3>
-    <p>
-       This provides a standard, cross-platform way of describing where resources are located.
-      &nbsp;URIs are described in more detail in "<a href=
-      "Information collected by DROID.html#Location">Information collected by DROID</a>".
-    </p>
-    <h3>
-       File path
-    </h3>
-    <p>
-       The file system&nbsp;location of the resource being profiled, if the resource was directly
-      in a file system. &nbsp;Some files are not on the file system - for example, files inside a
-      zip file. In this case, the file paths are written relative to the parent file which
-      exists on the file system. Such paths also include the type of archive as a prefix.
-    </p>
-    <p>
-       Please note that file paths are platform dependent (they are different on Windows and unix).
-      &nbsp;DROID will write out file paths for the system on which it is currently running.
-      &nbsp;This means that if you profile files on a unix machine, then export the profiles on a
-      Windows machine, the file paths will be written out as if they were Windows file paths, and
-      vice versa.
-    </p>
-    <h3>
-       Name
-    </h3>
-    <p>
-       The file name of the resource being profiled.
-    </p>
-    <h3>
-       <a id="Method" name="Method">Method</a>
-    </h3>
-    <p>
-       This field gives the method by which a resource identification has been made. &nbsp;DROID
-      can recognise resources by several methods:
-    </p>
-    <ul>
-      <li>
-        <b>Extension</b> - the file format was identified only by its filename <a href=
-        "#Extension">extension</a>. &nbsp;This method may not be very reliable, as the filename
-        extension may be wrong. &nbsp;It is only used when DROID cannot identify a resource by
-        another method, and cannot usually identify what the version of a file format is, only its
-        broad type.
-      </li>
-      <li>
-        <b>Signature</b> - the file format was identified by finding a file format signature inside
-        the file itself. &nbsp;This method is more reliable than filename extensions, and can
-        identify the precise version of a file format.
-      </li>
-      <li>
-        <b>Container</b> - the file format was identified by finding embedded files and patterns
-        within them. &nbsp;This method is as reliable as signature identifications, and can be more
-        reliable.
-      </li>
-    </ul>
-    <h3>
-       <a id="Job status" name="Job status">Job status</a>
-    </h3>
-    <p>
-       This field gives the identification status of a resource. &nbsp;It can have several values:
-    </p>
-    <ul>
-      <li>
-        <b>Not done</b> - the resource has not yet been profiled.
-      </li>
-      <li>
-        <b>Done</b> - the resource was processed with no errors.
-      </li>
-      <li>
-        <b>Access denied</b> - the operating system refused to give DROID read permissions to the
-        resource.
-      </li>
-      <li>
-        <b>Not found</b> - the resource was moved or deleted before DROID could read it.
-      </li>
-      <li>
-        <b>Error</b> - an error occurred while trying to profile a resource. &nbsp;For example, if
-        DROID is prevented from reading a file due to the user not having read permissions to it,
-        this will result in a profiling error for that file.
-      </li>
-    </ul>
-    <h3>
-       <a id="Size" name="Size">Size (bytes)</a>
-    </h3>
-    <p>
-       The size in bytes of a file. &nbsp;Only files have a size - folders do not. &nbsp;However,
-      note that some files can contain other&nbsp;files inside them, for example zip files.
-      &nbsp;In this case, the zip file has a size (as it is a file), and so do the files inside it.
-      &nbsp;The size reported in all cases is the uncompressed size of each file, as it would
-      appear if extracted from the container file.
-    </p>
-    <h3>
-       Type
-    </h3>
-    <p>
-       DROID categorises the files and folders it profiles as being one of three types:
-    </p>
-    <ul>
-      <li>
-        <img src="../Images/fileResourceType.gif">
-        &nbsp;File&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-      </li>
-      <li>
-        <img src="../Images/folderResourceType.gif">
-        &nbsp;Folder&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-      </li>
-      <li>
-        <img src="../Images/containerResourceType.gif"> &nbsp;Archival file&nbsp;(e.g. zip)
-      </li>
-    </ul>
-    <h3>
-       <a id="Extension" name="Extension">Extension</a>
-    </h3>
-    <p>
-       The filename extension of a file, which is the last part of a filename following a full
-      stop.&nbsp;&nbsp;Only files have extensions, as they indicate the type of the file.
-      &nbsp;Even if a folder has a full stop in its name, it will not be assigned an extension.
-    </p>
-    <h3>
-       <a id="Last Modified" name="Last Modified">Last modified</a>
-    </h3>
-    <p>
-       The date and time on which a resource was last modified.
-    </p>
-    <h3>
-       MD5, SHA1, SHA256 or SHA512 hash
-    </h3>
-    <p>
-       If you have enabled <a href="Change preferences.html#GenerateHash">hash generation</a> in
-      the preferences, then this column will contain the MD5, SHA1, SHA256 or SHA512 hash for each file and archival file
-      processed. &nbsp;See "<a href="Detecting duplicate files.html">Detecting duplicate files</a>"
-      for more information on hashes.
-    </p>
-    <h3>
-       <a id="PUID" name="PUID">PUID</a>
-    </h3>
-    <p>
-       The&nbsp;PRONOM Unique IDentifier (PUID) identifies the precise file format of a profiled
-      file. When a resource has been identified, it is assigned a PUID. &nbsp;&nbsp;A unique
-      identifier exists for every file format that DROID can recognise, and these identifiers are
-      maintained in the <a href="http://www.nationalarchives.gov.uk/pronom">PRONOM</a><img src=
-      "../Images/Icon_External_Link.png">&nbsp;technical registry database, hosted at the UK
-      National Archives.
-    </p>
-    <h3>
-       <a id="Mime type" name="Mime type">Mime type</a>
-    </h3>
-    <p>
-       The mime-type of an identified file format is a high level format identifier assigned by the
-      <a href="http://www.iana.org/assignments/media-types/">Internet Assigned Numbers</a><img src=
-      "../Images/Icon_External_Link.png">. &nbsp;It is widely used in email and other internet
-      protocols to identify the type of resource. &nbsp;Not all file formats identified by DROID
-      have an assigned mime-type, and different <a href="#PUID">PUIDs</a> assigned by DROID can
-      have the same mime-type
-    </p>
-    <h3>
-       <a id="Format" name="Format">Format</a> Name
-    </h3>
-    <p>
-       The name of an identified&nbsp;file format, as listed in the <a href=
-      "http://www.nationalarchives.gov.uk/pronom">PRONOM</a><img src=
-      "../Images/Icon_External_Link.png">&nbsp;technical registry against its <a href=
-      "#PUID">PUID</a>.
-    </p>
-    <h3>
-       <a id="Version" name="Version">Format Version</a>
-    </h3>
-    <p>
-       The version of an identified file format, as listed in the <a href=
-      "http://www.nationalarchives.gov.uk/pronom">PRONOM</a><img src=
-      "../Images/Icon_External_Link.png">&nbsp;technical registry against its <a href=
-      "#PUID">PUID</a>. &nbsp;Not all file formats have a defined version, so this field can be
-      blank even when a file has a PUID.
-    </p>
+
     <p>
     <h2>
       <a id="#SelectExportTemplate" name="SelectExportTemplate">Selecting a predefined Export Template for export</a>
@@ -312,9 +324,10 @@
       columns to be exported. Using a template, you can customise headers for the data columns, add new columns
       to the export, convert the data in a column to be uppercase / lowercase and change the order in which columns
       appear in the export. You can make an export template available to Droid by copying it into the
-      ".droid6\export_templates" folder. An example template is shown below:
+      ".droid6\export_templates" folder. You can customise the columns listed in the <a href="#CSVColumns">CSV Columns</a> section.
     </p>
     <p>
+      An example template is shown below:
       <pre>
         <code>version 1.0</code>
         <code>Identifier: $ID</code>
@@ -325,7 +338,7 @@
     </p>
     <p>
       The above template indicates:
-      <ol>
+    <ol>
       <li> The template is defined in version 1.0 of template syntax </li>
       <li> There are 4 columns to be exported in the order Identifier, LowerName, Language and Submitter</li>
       <li> Values in the column "Identifier" are populated using values in the "ID" column</li>
@@ -333,6 +346,20 @@
       <li> There is a non-profile column called "Language" and the values are hardcoded to "Simplified English"</li>
       <li> There is a non-profile column called "Submitter" and the values are left empty </li>
     </ol>
+    </p>
+
+    <p>
+      Following table describes the operations currently supported by DROID for data modifications.
+      These operations can be applied to data columns listed in the <a href="#CSVColumns">CSV Columns</a> table.
+    <p>
+    <table style="border:1px solid #000" cellpadding="10">
+      <tr>
+        <th style="border:1px solid #000" bgcolor="#000000"><font color="#ffffff"/>Operation</th>
+        <th style="border:1px solid #000" bgcolor="#000000"><font color="#ffffff"/>Description</th>
+      </tr>
+      <tr><td>LCASE</td><td>Converts the data from specified column to lower case e.g. LCASE($TYPE)</td></tr>
+      <tr><td>UCASE</td><td>Converts the data from specified column to upper case e.g. UCASE($FORMAT_NAME)</td></tr>
+    </table>
     </p>
     <p>
     <h2>

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -92,7 +92,7 @@
         <spring.version>5.3.27</spring.version>
         <hibernate.version>5.4.1.Final</hibernate.version>
         <derby.version>10.13.1.1</derby.version>
-        <cxf.version>3.5.5</cxf.version>
+        <cxf.version>3.5.8</cxf.version>
         <java.iso-tools.version>2.1.0</java.iso-tools.version>
         <jaxb.version>2.3.1</jaxb.version>
         <flying-saucer.version>9.1.22</flying-saucer.version>


### PR DESCRIPTION
Merging the error message improvements into the release branch
The main change is, 
Earlier the order of checks was 
1) Is it a profile results column?
2) Is it a constant string column?
3) Anything else - treat it as Data modifier column 

Now we have changed the checking order between 2 and 3, this means "anything else" is treated as a constant string column and automatically, the associated error messages indicate syntax error accordingly