### PR TITLE
Updated to latest JRE, increased max memory and updated docs to reflect the changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # DROID (Digital Record Object Identification) 
 
 [![CI](https://github.com/digital-preservation/droid/workflows/CI/badge.svg)](https://github.com/digital-preservation/droid/actions?query=workflow%3ACI)
-[![Build status](https://ci.appveyor.com/api/projects/status/hrr6c3ckbghjvd7h/branch/master?svg=true)](https://ci.appveyor.com/project/dpreservation/droid/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/digital-preservation/droid/badge.svg?branch=master)](https://coveralls.io/github/digital-preservation/droid?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/uk.gov.nationalarchives/droid/badge.svg)](https://search.maven.org/search?q=g:uk.gov.nationalarchives)
 

--- a/README.md
+++ b/README.md
@@ -111,17 +111,17 @@ Once the code is cloned into a folder (e.g. `droid`), executing `mvn clean insta
 
 ### Linux / OSX users
 
-You will need JAVA 8 to 11 installed to run DROID.
+You will need JAVA 8 to 17 installed to run DROID.
 
-Unpack the archive `droid-binary-${VERSION}-bin-unix.zip`, then use the `droid.sh` script to run the application.
+Unpack the archive `droid-binary-${VERSION}-bin.zip`, then use the `droid.sh` script to run the application.
 
 ### Windows users
 Archive  `droid-binary-${VERSION}-bin-win64-with-jre.zip`
 
 
-You will need JAVA 8 to 11 installed to run DROID. For Windows users who might not be able to install JAVA, the provided bundle includes JAVA 11.
+You will need JAVA 8 to 17 installed to run DROID. For Windows users who might not be able to install JAVA, the provided bundle includes JAVA 17.
 
-Unpack the archive `droid-binary-${VERSION}-bin-win32-with-jre.zip`, then use the `droid.bat` script to run the application.
+Unpack the archive `droid-binary-${VERSION}-bin-win64-with-jre.zip`, then use the `droid.bat` script to run the application.
 
 ## Signatures
 

--- a/droid-binary/bin/droid.bat
+++ b/droid-binary/bin/droid.bat
@@ -94,14 +94,14 @@ REM ---------------
 REM This is the maximum memory DROID can use in megabytes.
 REM Remove the "REM " from the line below and set the maximum memory after the "=".
 REM Also configure this property using the environment variable: droidMemory.
-REM SET droidMemory=512
+REM SET droidMemory=1024
 
 
 
 REM Assemble options
 REM ================
-REM Default to using 512 megabytes of memory if no other settings provided:
-SET DROID_OPTIONS="-Xmx512m"
+REM Default to using 1024 megabytes of memory if no other settings provided:
+SET DROID_OPTIONS="-Xmx1024m"
 
 IF "%droidMemory%"=="" GOTO UserDir
 SET DROID_OPTIONS="-Xmx%droidMemory%m"

--- a/droid-binary/bin/droid.sh
+++ b/droid-binary/bin/droid.sh
@@ -86,7 +86,7 @@ logLevel=""
 # Max memory: droidMemory
 # -----------------------
 # The maximum memory for DROID to use in megabytes.
-droidMemory="512m"
+droidMemory="1024m"
 
 
 # Run DROID:

--- a/droid-binary/pom.xml
+++ b/droid-binary/pom.xml
@@ -34,7 +34,7 @@
                         </goals>
                         <configuration>
                             <!-- To update, retrieve link for 64 bit Windows jre from https://adoptium.net -->
-                            <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jre_x64_windows_hotspot_17.0.9_9.zip</url>
+                            <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_x64_windows_hotspot_17.0.11_9.zip</url>
                             <unpack>false</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
@@ -55,9 +55,9 @@
                         <configuration>
                             <target>
                                 <!-- Update binary from https://adoptopenjdk.net/releases.html -->
-                                <unzip dest="${project.build.directory}/jre_tmp/" src="${project.build.directory}/OpenJDK17U-jre_x64_windows_hotspot_17.0.9_9.zip" />
+                                <unzip dest="${project.build.directory}/jre_tmp/" src="${project.build.directory}/OpenJDK17U-jre_x64_windows_hotspot_17.0.11_9.zip" />
                                 <move todir="${project.build.directory}/jre-windows/">
-                                    <fileset dir="${project.build.directory}/jre_tmp/jdk-17.0.9+9-jre/">
+                                    <fileset dir="${project.build.directory}/jre_tmp/jdk-17.0.11+9-jre/">
                                         <include name="**/*" />
                                     </fileset>
                                 </move>

--- a/droid-help/src/main/resources/Web pages/FAQ.html
+++ b/droid-help/src/main/resources/Web pages/FAQ.html
@@ -125,7 +125,7 @@
        <a id="JavaVersion" name="JavaVersion">What</a> version of Java do I need?
     </h3>
     <p>
-      If you are on Windows, a package is provided which also includes JRE with the droid binary. To use the version without Java bundled, you will need to have Java 8 to 12 installed on your machine in order to run DROID.
+      If you are on Windows, a package is provided which also includes JRE with the droid binary. To use the version without Java bundled, you will need to have Java 8 to 17 installed on your machine in order to run DROID.
       The latest JAVA updates can be obtained from <a href=
       "http://www.oracle.com/technetwork/java/index.html">oracle.com/technetwork/java/index.html</a>.
     </p>

--- a/droid-help/src/main/resources/Web pages/Startup configuration.html
+++ b/droid-help/src/main/resources/Web pages/Startup configuration.html
@@ -137,7 +137,7 @@
     <p>
        Java programs can only use as much memory as the&nbsp;Java Runtime Environment sets aside
       for them. &nbsp;By default, this value is often quite low. We recommend that DROID runs
-      with up to 1024Mb of memory potentially available, which is the default when DROID runs if no
+      with up to 1024MB of memory potentially available, which is the default when DROID runs if no
       further configuration is done. &nbsp;
     </p>
     <p>
@@ -148,7 +148,7 @@
     <ul>
       <li>
         Default value (running through scripts and the DROID.exe file): <b><font face=
-        "Monospaced, Courier New, Courier, mono">1024Mb</font></b>
+        "Monospaced, Courier New, Courier, mono">1024MB</font></b>
       </li>
       <li>
         Environment variable: <i><b><font face=

--- a/droid-help/src/main/resources/Web pages/Startup configuration.html
+++ b/droid-help/src/main/resources/Web pages/Startup configuration.html
@@ -136,8 +136,8 @@
     </h3>
     <p>
        Java programs can only use as much memory as the&nbsp;Java Runtime Environment sets aside
-      for them. &nbsp;By default, this value is often quite low. &nbsp;We recommend that DROID runs
-      with up to 512Mb of memory potentially available, which is the default when DROID runs if no
+      for them. &nbsp;By default, this value is often quite low. We recommend that DROID runs
+      with up to 1024Mb of memory potentially available, which is the default when DROID runs if no
       further configuration is done. &nbsp;
     </p>
     <p>
@@ -148,7 +148,7 @@
     <ul>
       <li>
         Default value (running through scripts and the DROID.exe file): <b><font face=
-        "Monospaced, Courier New, Courier, mono">512Mb</font></b>
+        "Monospaced, Courier New, Courier, mono">1024Mb</font></b>
       </li>
       <li>
         Environment variable: <i><b><font face=


### PR DESCRIPTION
1) Updated the Readme and configuration section to say "upto Java 17"
2) Bundled latest JRE
3) Increased the default max memory to 1024MB in startup scripts 