### PR TITLE
DR2-2038 Upate Derby database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [8, 11, 17]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.jdk }}
+          java-version: 21
           distribution: temurin
       - name: Cache Maven packages
         uses: actions/cache@v2
@@ -29,6 +28,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven Build
-        run: mvn -V -B -DskipTests=true install
+        run: mvn -V -B -DskipTests=true install -DnvdApiKey=${{ secrets.NVD_API_KEY }}
       - name: Maven Test
-        run: mvn -B verify
+        run: mvn -B verify -DnvdApiKey=${{ secrets.NVD_API_KEY }}

--- a/droid-binary/dependency-check/suppressions.xml
+++ b/droid-binary/dependency-check/suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes><![CDATA[
-   file name: derby-10.13.1.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.derby/derby@.*$</packageUrl>
-        <cve>CVE-2022-46337</cve>
-    </suppress>
 </suppressions>
-

--- a/droid-binary/pom.xml
+++ b/droid-binary/pom.xml
@@ -34,7 +34,7 @@
                         </goals>
                         <configuration>
                             <!-- To update, retrieve link for 64 bit Windows jre from https://adoptium.net -->
-                            <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_x64_windows_hotspot_17.0.11_9.zip</url>
+                            <url>https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jre_x64_windows_hotspot_21.0.5_11.zip</url>
                             <unpack>false</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
@@ -55,9 +55,9 @@
                         <configuration>
                             <target>
                                 <!-- Update binary from https://adoptopenjdk.net/releases.html -->
-                                <unzip dest="${project.build.directory}/jre_tmp/" src="${project.build.directory}/OpenJDK17U-jre_x64_windows_hotspot_17.0.11_9.zip" />
+                                <unzip dest="${project.build.directory}/jre_tmp/" src="${project.build.directory}/OpenJDK21U-jre_x64_windows_hotspot_21.0.5_11.zip" />
                                 <move todir="${project.build.directory}/jre-windows/">
-                                    <fileset dir="${project.build.directory}/jre_tmp/jdk-17.0.11+9-jre/">
+                                    <fileset dir="${project.build.directory}/jre_tmp/jdk-21.0.5+11-jre/">
                                         <include name="**/*" />
                                     </fileset>
                                 </move>

--- a/droid-command-line/dependency-check/suppressions.xml
+++ b/droid-command-line/dependency-check/suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes><![CDATA[
-   file name: derby-10.13.1.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.derby/derby@.*$</packageUrl>
-        <cve>CVE-2022-46337</cve>
-    </suppress>
 </suppressions>
-

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/DroidCommandLineTest.java
@@ -32,7 +32,6 @@
 package uk.gov.nationalarchives.droid.command;
 
 import junit.framework.Assert;
-import net.bytebuddy.asm.Advice;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/droid-export/dependency-check/suppressions.xml
+++ b/droid-export/dependency-check/suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes><![CDATA[
-   file name: derby-10.13.1.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.derby/derby@.*$</packageUrl>
-        <cve>CVE-2022-46337</cve>
-    </suppress>
 </suppressions>
-

--- a/droid-export/src/test/resources/jpa-test.properties
+++ b/droid-export/src/test/resources/jpa-test.properties
@@ -30,7 +30,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-datasource.driverClassName=org.apache.derby.jdbc.EmbeddedDriver
+datasource.driverClassName=org.apache.derby.iapi.jdbc.AutoloadedDriver
 datasource.url=jdbc:derby:droid-test-db;create=true
 datasource.username=droid_user
 datasource.password=droid_user

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -91,7 +91,7 @@
 
         <spring.version>5.3.27</spring.version>
         <hibernate.version>5.4.1.Final</hibernate.version>
-        <derby.version>10.13.1.1</derby.version>
+        <derby.version>10.17.1.0</derby.version>
         <cxf.version>3.5.9</cxf.version>
         <java.iso-tools.version>2.1.0</java.iso-tools.version>
         <jaxb.version>2.3.1</jaxb.version>
@@ -764,7 +764,7 @@ Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="${project.organ
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.6.1</version>
+                <version>5.15.2</version>
             </dependency>
             <dependency>
                 <groupId>xmlunit</groupId>

--- a/droid-report-interfaces/dependency-check/suppressions.xml
+++ b/droid-report-interfaces/dependency-check/suppressions.xml
@@ -1,10 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes><![CDATA[
-   file name: derby-10.13.1.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.derby/derby@.*$</packageUrl>
-        <cve>CVE-2022-46337</cve>
-    </suppress>
 </suppressions>

--- a/droid-report/dependency-check/suppressions.xml
+++ b/droid-report/dependency-check/suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes><![CDATA[
-   file name: derby-10.13.1.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.derby/derby@.*$</packageUrl>
-        <cve>CVE-2022-46337</cve>
-    </suppress>
 </suppressions>
-

--- a/droid-report/src/test/resources/jpa-test.properties
+++ b/droid-report/src/test/resources/jpa-test.properties
@@ -30,7 +30,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-datasource.driverClassName=org.apache.derby.jdbc.EmbeddedDriver
+datasource.driverClassName=org.apache.derby.iapi.jdbc.AutoloadedDriver
 datasource.url=jdbc:derby:droid-test-db;create=true
 datasource.username=droid_user
 datasource.password=droid_user

--- a/droid-results/dependency-check/suppressions.xml
+++ b/droid-results/dependency-check/suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes><![CDATA[
-   file name: derby-10.13.1.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.derby/derby@.*$</packageUrl>
-        <cve>CVE-2022-46337</cve>
-    </suppress>
 </suppressions>
-

--- a/droid-results/src/main/resources/jpa.properties
+++ b/droid-results/src/main/resources/jpa.properties
@@ -30,7 +30,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-datasource.driverClassName=org.apache.derby.jdbc.EmbeddedDriver
+datasource.driverClassName=org.apache.derby.iapi.jdbc.AutoloadedDriver
 datasource.username=droid_user
 datasource.password=droid_user
 datasource.maxActive=100

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ProfileManagerImplTest.java
@@ -72,7 +72,7 @@ import uk.gov.nationalarchives.droid.util.FileUtil;
  */
 public class ProfileManagerImplTest {
 
-    private static final String DERBY_DRIVER_CLASSNAME = "org.apache.derby.jdbc.EmbeddedDriver";
+    private static final String DERBY_DRIVER_CLASSNAME = "org.apache.derby.iapi.jdbc.AutoloadedDriver";
     
     private ProfileManagerImpl profileManager;
     private ProfileSpecDao profileSpecDao;

--- a/droid-results/src/test/resources/jpa-test.properties
+++ b/droid-results/src/test/resources/jpa-test.properties
@@ -30,7 +30,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-datasource.driverClassName=org.apache.derby.jdbc.EmbeddedDriver
+datasource.driverClassName=org.apache.derby.iapi.jdbc.AutoloadedDriver
 datasource.url=jdbc:derby:target/droid-test-db;create=true
 datasource.username=droid_user
 datasource.password=droid_user

--- a/droid-swing-ui/dependency-check/suppressions.xml
+++ b/droid-swing-ui/dependency-check/suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-        <notes><![CDATA[
-   file name: derby-10.13.1.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.derby/derby@.*$</packageUrl>
-        <cve>CVE-2022-46337</cve>
-    </suppress>
 </suppressions>
-

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ProfileFileChooser.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ProfileFileChooser.java
@@ -59,6 +59,7 @@ public class ProfileFileChooser extends JFileChooser {
         FileNameExtensionFilter filter = new FileNameExtensionFilter("DROID 6 profile", "droid");
         addChoosableFileFilter(filter);
         setFileFilter(filter);
+        setMultiSelectionEnabled(false);
     }
     
     /**


### PR DESCRIPTION
This is now the latest version of derby.

This version needs Java 21. I've updated the bundled version to use 21.

The name of the driver class has changed and has been updated in all of
the places it's set.

I wanted to get this working on 21 anyway. DROID itself runs happily on
21 but the tests weren't passing because of how old Mockito was so I've
upgraded that.

I've removed versions 7 and 11 and 17 from the CI workflow.

I've updated the ci workflow to use an NVD API key which is set in the
repository secrets to stop the ci run taking an hour periodically.

I've removed the supressions for the old version of the derby DB

The last thing was an odd test failure in the tests for ProfileFileChooser
It was saying that multiSelectionEnabled was true when run on Java 21.
If you run DROID on Java 21 then multi selection is enabled. I'm not
sure why but setting it to false in the setup method brings back the old
behaviour.