### PR TITLE
Fix Implicit narrowing conversion in compound assignment alert

### DIFF
--- a/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/ByteSequence.java
+++ b/droid-core/src/main/java/uk/gov/nationalarchives/droid/core/signature/droid6/ByteSequence.java
@@ -459,8 +459,8 @@ public class ByteSequence extends uk.gov.nationalarchives.droid.core.signature.x
      * @param targetFile
      * @return the offset
      */
-    private int getIndirectOffset(final ByteReader targetFile) throws IOException {
-        int offset = 0;
+    private long getIndirectOffset(final ByteReader targetFile) throws IOException {
+        long offset = 0;
         if (this.hasIndirectOffset) {
             long power = 1;
             long offsetLocation = indirectOffsetLocation;


### PR DESCRIPTION
This method is called like

```java
final long offset = getIndirectOffset(targetFile);
```

so this is the only change that is needed.
