### PR TITLE
Explicitly add Derby dependency

### DIFF
--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -263,7 +263,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>12.0.2</version>
+                <version>12.1.0</version>
                 <configuration>
                     <failBuildOnCVSS>8</failBuildOnCVSS>
                 </configuration>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -303,6 +303,11 @@
 			<version>2.4.13</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.derby</groupId>
+			<artifactId>derby</artifactId>
+			<version>${derby.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -111,6 +111,7 @@
 							<failOnWarning>true</failOnWarning>
 							<ignoredUnusedDeclaredDependencies>
 								<ignoredUnusedDeclaredDependency>uk.gov.nationalarchives:droid-container:jar:${project.version}</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.apache.derby:derby:jar:${derby.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>javax.transaction:jta:jar:${jta.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.apache.cxf:cxf-rt-frontend-jaxws:jar:${cxf.version}</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.apache.cxf:cxf-rt-bindings-soap:jar:${cxf.version}</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
For some reason, some of the recent dependency updates have broken this
and we're now getting Failed to load class of driverClassName org.apache.derby.iapi.jdbc.AutoloadedDriver in HikariConfig

This stops the error.
