### PR TITLE
Add glob matching and container file name matching.

### DIFF
--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/FileMatcher.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/FileMatcher.java
@@ -48,12 +48,12 @@ public class FileMatcher {
         this.fileSystem = FileSystems.getFileSystem(URI.create("file:///"));
     }
 
-    public boolean fileMatches(String fileName, String toMatch, String containerFileName) {
-        return fileName.equals(toMatch) || globMatches(fileName, toMatch) || matchesName(fileName, toMatch, containerFileName);
+    public boolean fileMatches(String filePath, String toMatch, String containerFileName) {
+        return filePath.equals(toMatch) || matchesContainerName(filePath, toMatch, containerFileName) || globMatches(filePath, toMatch);
     }
 
-    private boolean matchesName(String fileName, String toMatch, String containerFileName) {
-        if (fileName != null && fileName.startsWith(CONTAINER_NAME_PLACEHOLDER)) {
+    private boolean matchesContainerName(String fileName, String toMatch, String containerFileName) {
+        if (fileName != null && toMatch != null && containerFileName != null && fileName.startsWith(CONTAINER_NAME_PLACEHOLDER)) {
             return toMatch.equals(fileName.replace(CONTAINER_NAME_PLACEHOLDER, FilenameUtils.removeExtension(containerFileName)));
         }
         return false;

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/FileMatcher.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/FileMatcher.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.gov.nationalarchives.droid.container;
+
+import org.apache.commons.io.FilenameUtils;
+
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+
+public class FileMatcher {
+
+    private static final String CONTAINER_NAME_PLACEHOLDER = "{containerFileName}";
+
+    private final FileSystem fileSystem;
+
+    public FileMatcher() {
+        this.fileSystem = FileSystems.getFileSystem(URI.create("file:///"));
+    }
+
+    public boolean fileMatches(String fileName, String toMatch, String containerFileName) {
+        return fileName.equals(toMatch) || globMatches(fileName, toMatch) || matchesName(fileName, toMatch, containerFileName);
+    }
+
+    private boolean matchesName(String fileName, String toMatch, String containerFileName) {
+        if (fileName != null && fileName.startsWith(CONTAINER_NAME_PLACEHOLDER)) {
+            return toMatch.equals(fileName.replace(CONTAINER_NAME_PLACEHOLDER, FilenameUtils.removeExtension(containerFileName)));
+        }
+        return false;
+    }
+
+    private boolean globMatches(String pattern, String toMatch) {
+        PathMatcher pathMatcher = fileSystem.getPathMatcher("glob:" + pattern);
+        return pathMatcher.matches(fileSystem.getPath(toMatch));
+    }
+
+
+}

--- a/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ole2/Ole2IdentifierEngine.java
+++ b/droid-container/src/main/java/uk/gov/nationalarchives/droid/container/ole2/Ole2IdentifierEngine.java
@@ -104,7 +104,7 @@ public class Ole2IdentifierEngine extends AbstractIdentifierEngine {
                 boolean needsBinaryMatch = false;
 
                 for (ContainerSignatureMatch match : matches.getContainerSignatureMatches()) {
-                    match.matchFileEntry(entryName);
+                    match.matchFileEntry(entryName, request.getFileName());
                     if (match.needsBinaryMatch(entryName)) {
                         needsBinaryMatch = true;
                     }

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerMatchUtils.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerMatchUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package uk.gov.nationalarchives.droid.container;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class ContainerMatchUtils {
+
+
+    public record ContainerTestData(String containerName, String pattern, List<String> willMatch,
+                                    List<String> willNotMatch) {
+    }
+
+
+    public static Stream<ContainerTestData> getContainerTestData() {
+        String containerName = "test.zip";
+        return Stream.of(
+                new ContainerTestData(
+                        containerName,
+                        "*.txt",
+                        List.of("file.txt", "notes.txt"),
+                        List.of("file.md", "image.jpg")
+                ),
+                new ContainerTestData(
+                        containerName,
+                        "*.{jpg,png,gif}",
+                        List.of("photo.jpg", "graphic.png", "animation.gif"),
+                        List.of("document.pdf", "image.bmp")
+                ),
+                new ContainerTestData(containerName,
+                        "file*",
+                        List.of("file1", "file2.txt", "file_test.md"),
+                        List.of("afile.txt", "otherfile.md")
+                ),
+                new ContainerTestData(containerName,
+                        "file?.txt",
+                        List.of("file1.txt", "file2.txt"),
+                        List.of("file10.txt", "fileAB.txt")
+                ),
+                new ContainerTestData(containerName,
+                        "test/**",
+                        List.of("test/file.txt", "test/subdir/file.txt"),
+                        List.of("notest/file.txt", "testfile.txt")
+                ),
+                new ContainerTestData(containerName,
+                        "**/*.scala",
+                        List.of("/Main.scala", "src/main/Example.scala"),
+                        List.of("Main.java", "notes.txt")
+                ),
+                new ContainerTestData(containerName,
+                        "**/test_*.py",
+                        List.of("/dir1/test_abc.py", "subdir/test_xyz.py"),
+                        List.of("my_test.py", "testsuite.py")
+                ),
+                new ContainerTestData(containerName,
+                        "src/**/main.*",
+                        List.of("src/main/main.scala", "src/app/main.py"),
+                        List.of("src/app/mainfile.py")
+                ),
+                new ContainerTestData(containerName,
+                        "logs/**/*2024*.log",
+                        List.of("logs/jan/2024_error.log", "logs/feb/2024_info.log"),
+                        List.of("logs/2023_info.log", "logs/future_2025.log")
+                ),
+                new ContainerTestData(
+                        "test.zip",
+                        "{containerFileName}.xml",
+                        List.of("test.xml"),
+                        List.of("test.txt", "test.pdf", "test2.xml")
+                ),
+                new ContainerTestData("test2.7z",
+                        "{containerFileName}",
+                        List.of("test2"),
+                        List.of("test2.txt", "test2.xml", "test")
+                ),
+                new ContainerTestData("test3",
+                        "{containerFileName}.pdf",
+                        List.of("test3.pdf"),
+                        List.of("test3.txt", "test3.xml", "test3")
+                ),
+                new ContainerTestData("test3.tar.zip",
+                        "{containerFileName}.txt",
+                        List.of("test3.tar.txt"),
+                        List.of("test3.txt", "test3.xml", "test3.tar")
+                )
+        );
+    }
+}

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/ContainerSignatureMatchTest.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.nationalarchives.droid.core.signature.ByteReader;
 import uk.gov.nationalarchives.droid.core.signature.droid6.InternalSignatureCollection;
@@ -65,14 +64,15 @@ public class ContainerSignatureMatchTest {
         
         Map<String, ContainerFile> files = new HashMap<String, ContainerFile>();
         files.put("entry0", new ContainerFile());
-        
-        
+
+        String containerFileName = "test.zip";
+
         ContainerSignature sig = mock(ContainerSignature.class);
         when(sig.getFiles()).thenReturn(files);
         
         match = new ContainerSignatureMatch(sig, -1L);
         
-        match.matchFileEntry("entry1");
+        match.matchFileEntry("entry1", containerFileName);
         assertFalse(match.isMatch());
         
     }
@@ -83,20 +83,44 @@ public class ContainerSignatureMatchTest {
         Map<String, ContainerFile> files = new HashMap<String, ContainerFile>();
         files.put("entry1", new ContainerFile());
         files.put("entry2", new ContainerFile());
-        
+
+        String containerFileName = "test.zip";
+
         ContainerSignature sig = mock(ContainerSignature.class);
         when(sig.getFiles()).thenReturn(files);
         
         match = new ContainerSignatureMatch(sig, -1L);
         assertFalse(match.isMatch());
         
-        match.matchFileEntry("entry1");
+        match.matchFileEntry("entry1", containerFileName);
         assertFalse(match.isMatch());
         
-        match.matchFileEntry("entry2");
+        match.matchFileEntry("entry2", containerFileName);
         assertTrue(match.isMatch());
     }
-    
+
+    @Test
+    public void testFileMatches() {
+        ContainerMatchUtils.getContainerTestData().forEach(testData -> {
+            Map<String, ContainerFile> files = new HashMap<>();
+            files.put(testData.pattern(), new ContainerFile());
+
+            ContainerSignature sig = mock(ContainerSignature.class);
+            when(sig.getFiles()).thenReturn(files);
+
+            testData.willMatch().forEach(willMatch -> {
+                ContainerSignatureMatch match = new ContainerSignatureMatch(sig, -1L);
+                match.matchFileEntry(willMatch, testData.containerName());
+                assertTrue(match.isMatch());
+            });
+
+            testData.willNotMatch().forEach(willNotMatch -> {
+                ContainerSignatureMatch match = new ContainerSignatureMatch(sig, -1L);
+                match.matchFileEntry(willNotMatch, testData.containerName());
+                assertFalse(match.isMatch());
+            });
+        });
+    }
 
     @Test
     public void shouldMatchBinaryContentByFileNameWithTheFullPathWhenNoBinaryContent() {

--- a/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/zip/ZipFailureFallbackTest.java
+++ b/droid-container/src/test/java/uk/gov/nationalarchives/droid/container/zip/ZipFailureFallbackTest.java
@@ -75,8 +75,8 @@ public class ZipFailureFallbackTest {
     @Test
     public void testFileMatching() {
         ContainerMatchUtils.getContainerTestData().forEach(globTestData -> {
-            globTestData.willMatch().forEach(willMatch -> checkMatches(willMatch, globTestData.pattern(), globTestData.containerName(), Assert::assertTrue));
-            globTestData.willNotMatch().forEach(willNotMatch -> checkMatches(willNotMatch, globTestData.pattern(), globTestData.containerName(), Assert::assertFalse));
+            globTestData.willMatch().forEach(willMatch -> checkContainerSignatureMatches(willMatch, globTestData.pattern(), globTestData.containerName(), Assert::assertTrue));
+            globTestData.willNotMatch().forEach(willNotMatch -> checkContainerSignatureMatches(willNotMatch, globTestData.pattern(), globTestData.containerName(), Assert::assertFalse));
         });
 
     }
@@ -84,17 +84,17 @@ public class ZipFailureFallbackTest {
     @Test
     public void testValidZipFileMatches() {
         String fileName = "file.txt";
-        checkMatches(fileName, fileName, "test.zip", Assert::assertTrue);
+        checkContainerSignatureMatches(fileName, fileName, "test.zip", Assert::assertTrue);
     }
 
     @Test
     public void testNoMatchesIfFileNotFound() {
         String fileName = "file.txt";
         String missingFileName = "missingFile.txt";
-        checkMatches(fileName, missingFileName, "test.zip", Assert::assertFalse);
+        checkContainerSignatureMatches(fileName, missingFileName, "test.zip", Assert::assertFalse);
     }
 
-    private static void checkMatches(String filePath, String signatureFileName, String containerFileName, Consumer<Boolean> check) {
+    private static void checkContainerSignatureMatches(String filePath, String signatureFileName, String containerFileName, Consumer<Boolean> check) {
         try {
             byte[] zipBytes = createZipBytes(filePath);
             List<ContainerSignatureMatch> containerSignatureMatches = getContainerSignatureMatches(zipBytes, signatureFileName, containerFileName);

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
@@ -192,7 +192,7 @@ public class DroidMainFrame extends JFrame {
     /**
      * 
      */
-    void checkSignatureUpdates() {
+    public void checkSignatureUpdates() {
         final PropertiesConfiguration properties = globalContext.getGlobalConfig().getProperties();
         boolean autoCheck = properties.getBoolean(DroidGlobalProperty.UPDATE_AUTO_CHECK.getName());
         boolean checkNow = properties.getBoolean(DroidGlobalProperty.UPDATE_ON_STARTUP.getName());
@@ -265,7 +265,7 @@ public class DroidMainFrame extends JFrame {
         return filesToUpdate;
     }
 
-    private void createDefaultProfile() {
+    public void createDefaultProfile() {
         final NewProfileAction newProfileAction = 
             new NewProfileAction(droidContext, profileManager, jProfilesTabbedPane);
         newProfileAction.addPropertyChangeListener(evt -> {
@@ -283,7 +283,7 @@ public class DroidMainFrame extends JFrame {
         }
     }
 
-    private void init() {
+    public void init() {
         log.info("Starting DROID.");
         URL icon = getClass().getResource("/uk/gov/nationalarchives/droid/icons/DROID16.gif");
         setIconImage(new ImageIcon(icon).getImage());

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
@@ -483,7 +483,6 @@ public class ResourceSelectorDialog extends JDialog {
                 .addComponent(jLabel1, GroupLayout.DEFAULT_SIZE, 14, Short.MAX_VALUE)
                 .addContainerGap())
         );
-
         tree.setModel(getTreeModel());
         tree.setLargeModel(true);
         tree.setRootVisible(false);


### PR DESCRIPTION
This is trying to solve the issue here https://github.com/digital-preservation/pronom/issues/10

There are two changes.

One is to do glob matching on container file names. In both the
Ole2IdentifierEngine and the ZipIdentifierEngine, we at first try to get
the name from the container as is. If that doesn't work we do:

* Check if the string `{containerFileName}` is in the path. If it is,replace the placeholder with the container file name and match on that.
* Check if the path in the container file matches and files in the container using glob matching.

This is experimental and subject to change but as it shouldn't break any
existing functionality, I think this can go into main.
