### PR TITLE
Allow extension override.

### DIFF
--- a/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITest.java
+++ b/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITest.java
@@ -212,6 +212,21 @@ public class DroidAPITest {
         );
     }
 
+    static Stream<URI> noFileExtensionUris() {
+        return getUris("src/test/resources/test");
+    }
+
+    @ParameterizedTest
+    @MethodSource("noFileExtensionUris")
+    public void should_report_extension_only_match_if_extension_is_provided(URI uri) throws IOException {
+        List<ApiResult> results = api.submit(uri, "docx");
+
+        ApiResult result = results.getFirst();
+        assertThat(result.getExtension(), is("docx"));
+        assertThat(result.getMethod(), is(IdentificationMethod.EXTENSION));
+        assertThat(result.getPuid(), is("fmt/494"));
+    }
+
     @Execution(ExecutionMode.CONCURRENT)
     @ParameterizedTest
     @MethodSource("correctExtensionUris")

--- a/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITest.java
+++ b/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITest.java
@@ -227,6 +227,20 @@ public class DroidAPITest {
         assertThat(result.getPuid(), is("fmt/494"));
     }
 
+    static Stream<URI> docxWithoutExtensionUris() {return getUris("src/test/resources/word97");}
+
+    @ParameterizedTest
+    @MethodSource("docxWithoutExtensionUris")
+    public void should_return_extension_mismatch_if_extension_passed_does_not_match(URI uri) throws IOException {
+        List<ApiResult> results = api.submit(uri, "pdf");
+
+        ApiResult result = results.getFirst();
+        assertThat(result.getExtension(), is("pdf"));
+        assertThat(result.getMethod(), is(IdentificationMethod.CONTAINER));
+        assertThat(result.getPuid(), is("fmt/40"));
+        assertThat(result.isFileExtensionMismatch(), is(true));
+    }
+
     @Execution(ExecutionMode.CONCURRENT)
     @ParameterizedTest
     @MethodSource("correctExtensionUris")

--- a/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITestUtils.java
+++ b/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITestUtils.java
@@ -184,10 +184,10 @@ public class DroidAPITestUtils {
             byte[] buffer = new byte[length];
             int bytesRead = raf.read(buffer);
             return bytesRead == length ? buffer : Arrays.copyOf(buffer, bytesRead);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        } catch (IOException | NegativeArraySizeException e) {
+            return new byte[0];
         }
-        }
+    }
 
     public record ContainerType(String name, String id, String puid) {}
     public record ContainerFile(ContainerType containerType, String sequence, String puid, Optional<String> path) {}

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequest.java
@@ -52,7 +52,7 @@ public class FileSystemIdentificationRequest implements IdentificationRequest<Pa
 
     private static final int TOP_TAIL_BUFFER_CAPACITY = 8 * 1024 * 1024; // buffer 8Mb on the top and tail of files.
 
-    private final String extension;
+    private String extension;
     private final String fileName;
     private final long size;
     private WindowReader fileReader;
@@ -70,7 +70,6 @@ public class FileSystemIdentificationRequest implements IdentificationRequest<Pa
         requestMetaData = metaData;
         size = metaData.getSize();
         fileName = metaData.getName();
-        extension = ResourceUtils.getExtension(fileName);
     }
     
     /**
@@ -92,7 +91,15 @@ public class FileSystemIdentificationRequest implements IdentificationRequest<Pa
      */
     @Override
     public final String getExtension() {
-        return extension;
+        return extension == null ? ResourceUtils.getExtension(fileName) : extension;
+    }
+
+    /**
+     * Sets the file extension. This is used when it can't be determined from the file name
+     * @param extension The extension to set
+     */
+    public final void setExtension(final String extension) {
+        this.extension =  extension;
     }
     
     /**

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/FileSystemIdentificationRequest.java
@@ -40,6 +40,7 @@ import net.byteseek.io.reader.WindowReader;
 import net.byteseek.io.reader.FileReader;
 import net.byteseek.io.reader.cache.TopAndTailFixedLengthCache;
 import net.byteseek.io.reader.cache.WindowCache;
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationRequest;
 import uk.gov.nationalarchives.droid.core.interfaces.RequestIdentifier;
 
@@ -91,11 +92,11 @@ public class FileSystemIdentificationRequest implements IdentificationRequest<Pa
      */
     @Override
     public final String getExtension() {
-        return extension == null ? ResourceUtils.getExtension(fileName) : extension;
+        return StringUtils.isBlank(this.extension) ? ResourceUtils.getExtension(requestMetaData.getName()) : this.extension;
     }
 
     /**
-     * Sets the file extension. This is used when it can't be determined from the file name
+     * Sets the file extension. If this is set, this will be used as the file extension instead of an extension derived from the name
      * @param extension The extension to set
      */
     public final void setExtension(final String extension) {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpIdentificationRequest.java
@@ -35,6 +35,7 @@ import net.byteseek.io.reader.ReaderInputStream;
 import net.byteseek.io.reader.WindowReader;
 import net.byteseek.io.reader.cache.TopAndTailFixedLengthCache;
 import net.byteseek.io.reader.cache.WindowCache;
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationRequest;
 import uk.gov.nationalarchives.droid.core.interfaces.RequestIdentifier;
 
@@ -84,11 +85,11 @@ public class HttpIdentificationRequest implements IdentificationRequest<URI> {
      */
     @Override
     public final String getExtension() {
-        return extension == null ? ResourceUtils.getExtension(requestMetaData.getName()) : extension;
+        return StringUtils.isBlank(this.extension) ? ResourceUtils.getExtension(requestMetaData.getName()) : this.extension;
     }
 
     /**
-     * Sets the file extension. This is used when it can't be determined from the file name
+     * Sets the file extension. If this is set, this will be used as the file extension instead of an extension derived from the name
      * @param extension The extension to set
      */
     public final void setExtension(final String extension) {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpIdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpIdentificationRequest.java
@@ -53,6 +53,7 @@ public class HttpIdentificationRequest implements IdentificationRequest<URI> {
     private final long size;
     private final HttpClient client;
     private HttpUtils.HttpMetadata httpMetadata;
+    private String extension;
 
     public HttpIdentificationRequest(final RequestMetaData requestMetaData, final RequestIdentifier identifier, HttpClient httpClient) {
         this.identifier = identifier;
@@ -83,7 +84,15 @@ public class HttpIdentificationRequest implements IdentificationRequest<URI> {
      */
     @Override
     public final String getExtension() {
-        return ResourceUtils.getExtension(requestMetaData.getName());
+        return extension == null ? ResourceUtils.getExtension(requestMetaData.getName()) : extension;
+    }
+
+    /**
+     * Sets the file extension. This is used when it can't be determined from the file name
+     * @param extension The extension to set
+     */
+    public final void setExtension(final String extension) {
+        this.extension =  extension;
     }
 
     /**

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpWindowReader.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpWindowReader.java
@@ -61,7 +61,7 @@ public class HttpWindowReader extends AbstractReader implements SoftWindowRecove
     private HttpResponse<byte[]> responseWithRange(long rangeStart, long rangeEnd) {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(this.uri)
-                .header("Range", "bytes=" + rangeStart + "-" + (rangeEnd + this.windowSize - 1))
+                .header("Range", "bytes=" + rangeStart + "-" + rangeEnd)
                 .GET()
                 .build();
 

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3IdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3IdentificationRequest.java
@@ -35,6 +35,7 @@ import net.byteseek.io.reader.ReaderInputStream;
 import net.byteseek.io.reader.WindowReader;
 import net.byteseek.io.reader.cache.TopAndTailFixedLengthCache;
 import net.byteseek.io.reader.cache.WindowCache;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Uri;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationRequest;
@@ -85,11 +86,11 @@ public class S3IdentificationRequest implements IdentificationRequest<S3Uri> {
      */
     @Override
     public final String getExtension() {
-        return this.extension != null ? this.extension : ResourceUtils.getExtension(requestMetaData.getName());
+        return StringUtils.isBlank(this.extension) ? ResourceUtils.getExtension(requestMetaData.getName()) : this.extension;
     }
 
     /**
-     * Sets the file extension. This is used when it can't be determined from the file name
+     * Sets the file extension. If this is set, this will be used as the file extension instead of an extension derived from the name
      * @param extension The extension to set
      */
     public final void setExtension(String extension) {

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3IdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3IdentificationRequest.java
@@ -53,6 +53,7 @@ public class S3IdentificationRequest implements IdentificationRequest<S3Uri> {
 
     private final S3Client s3client;
     private final S3Utils.S3ObjectMetadata s3ObjectMetadata;
+    private String extension;
 
     public S3IdentificationRequest(final RequestMetaData requestMetaData, final RequestIdentifier identifier, final S3Client s3Client) {
         this.identifier = identifier;
@@ -84,7 +85,15 @@ public class S3IdentificationRequest implements IdentificationRequest<S3Uri> {
      */
     @Override
     public final String getExtension() {
-        return ResourceUtils.getExtension(requestMetaData.getName());
+        return this.extension != null ? this.extension : ResourceUtils.getExtension(requestMetaData.getName());
+    }
+
+    /**
+     * Sets the file extension. This is used when it can't be determined from the file name
+     * @param extension The extension to set
+     */
+    public final void setExtension(String extension) {
+        this.extension = extension;
     }
 
     /**


### PR DESCRIPTION
TDR have the case where there files in S3 have no extension. This allows
you to provide an extension which DROID will use rather than deriving it
from the name.
