### PR TITLE
Trim file path with spaces at the end for Windows.

### DIFF
--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datawriter/FormattedDataWriter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datawriter/FormattedDataWriter.java
@@ -98,7 +98,7 @@ public abstract  class FormattedDataWriter {
             String uriString = uri.toString();
             String urlSpace = "%20";
             if (uriString.endsWith(urlSpace) && SystemUtils.IS_OS_WINDOWS) {
-                return Paths.get(URI.create(uriString.substring(0, uriString.length() - urlSpace.length()))).toAbsolutePath().toString();
+                return Paths.get(URI.create(uriString.substring(0, uriString.length() - urlSpace.length()))).toAbsolutePath() + " ";
             }
             return Paths.get(uri).toAbsolutePath().toString();
         }

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datawriter/FormattedDataWriter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datawriter/FormattedDataWriter.java
@@ -89,6 +89,16 @@ public abstract  class FormattedDataWriter {
         return FilenameUtils.getName(name);
     }
 
+    private int countCharactersAtEndOfFileUri(URI uri, String character) {
+        String uriString = uri.toString();
+        int count = 0;
+        while (uriString.endsWith(character)) {
+            count++;
+            uriString = uriString.substring(0, uriString.length() - character.length());
+        }
+        return count;
+    }
+
     protected String toFilePath(URI uri) {
         if (uri == null) {
             log.warn("[URI not set]");
@@ -97,8 +107,9 @@ public abstract  class FormattedDataWriter {
         if (WriterConstants.FILE_URI_SCHEME.equals(uri.getScheme())) {
             String uriString = uri.toString();
             String urlSpace = "%20";
-            if (uriString.endsWith(urlSpace) && SystemUtils.IS_OS_WINDOWS) {
-                return Paths.get(URI.create(uriString.substring(0, uriString.length() - urlSpace.length()))).toAbsolutePath() + " ";
+            int spaceCount = countCharactersAtEndOfFileUri(uri, urlSpace);
+            if (spaceCount > 0 && !SystemUtils.IS_OS_WINDOWS) {
+                return Paths.get(URI.create(uriString.substring(0, uriString.length() - urlSpace.length() * spaceCount))).toAbsolutePath() + String.format("%" + spaceCount + "s", "");
             }
             return Paths.get(uri).toAbsolutePath().toString();
         }

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datawriter/FormattedDataWriter.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/datawriter/FormattedDataWriter.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.univocity.parsers.csv.CsvWriter;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +95,11 @@ public abstract  class FormattedDataWriter {
             return WriterConstants.EMPTY_STRING;
         }
         if (WriterConstants.FILE_URI_SCHEME.equals(uri.getScheme())) {
+            String uriString = uri.toString();
+            String urlSpace = "%20";
+            if (uriString.endsWith(urlSpace) && SystemUtils.IS_OS_WINDOWS) {
+                return Paths.get(URI.create(uriString.substring(0, uriString.length() - urlSpace.length()))).toAbsolutePath().toString();
+            }
             return Paths.get(uri).toAbsolutePath().toString();
         }
 

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
@@ -189,7 +189,7 @@ public class ItemWriterImplTest {
             final String expectedEntry = toCsvRow(new String[]{
                     "", "",
                     isNotWindows() ? "file:/my/file1.txt%20" : "file:/C:/my/file1.txt%20",
-                    isNotWindows() ? "/my/file1.txt" : "C:\\my\\file1.txt",
+                    isNotWindows() ? "/my/file1.txt " : "C:\\my\\file1.txt ",
                     "file1.txt",
                     "Signature",
                     "Done",

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
@@ -171,6 +171,48 @@ public class ItemWriterImplTest {
         }
     }
 
+    @Test
+    public void should_write_node_file_name_with_space_at_the_end() throws IOException {
+        when(config.getBooleanProperty(DroidGlobalProperty.CSV_EXPORT_ROW_PER_FORMAT)).thenReturn(false);
+
+        try(final Writer writer = new StringWriter()) {
+            List<ProfileResourceNode> nodes = new ArrayList<>();
+            Format id = buildFormat(1);
+            File f = isNotWindows() ? new File("/my/file1.txt ") : new File("C:/my/file1.txt ");
+            ProfileResourceNode node = buildProfileResourceNode(1, 1001L, f.toURI());
+            node.addFormatIdentification(id);
+            nodes.add(node);
+            itemWriter.setOptions(ExportOptions.ONE_ROW_PER_FORMAT);
+            itemWriter.open(writer);
+            itemWriter.write(nodes);
+
+            final String expectedEntry = toCsvRow(new String[]{
+                    "", "",
+                    isNotWindows() ? "file:/my/file1.txt%20" : "file:/C:/my/file1.txt%20",
+                    isNotWindows() ? "/my/file1.txt" : "C:\\my\\file1.txt",
+                    "file1.txt",
+                    "Signature",
+                    "Done",
+                    "1001",
+                    "File",
+                    "foo",
+                    testDateTimeString,
+                    "false",
+                    "11111111111111111111111111111111",
+                    "1",
+                    "fmt/1",
+                    "text/plain",
+                    "Plain Text",
+                    "1.0",
+            });
+
+            final String[] lines = writer.toString().split(LINE_SEPARATOR);
+            assertEquals(2, lines.length);
+            assertEquals(defaultHeaders, lines[0]);
+            assertEquals(expectedEntry, lines[1]);
+        }
+    }
+
 
     @Test
     public void should_write_one_node_as_one_row_per_format_export() throws IOException {

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
@@ -178,7 +178,7 @@ public class ItemWriterImplTest {
         try(final Writer writer = new StringWriter()) {
             List<ProfileResourceNode> nodes = new ArrayList<>();
             Format id = buildFormat(1);
-            File f = isNotWindows() ? new File("/my/file1.txt ") : new File("C:/my/file1.txt ");
+            File f = isNotWindows() ? new File("/my/file1.txt  ") : new File("C:/my/file1.txt  ");
             ProfileResourceNode node = buildProfileResourceNode(1, 1001L, f.toURI());
             node.addFormatIdentification(id);
             nodes.add(node);
@@ -188,8 +188,8 @@ public class ItemWriterImplTest {
 
             final String expectedEntry = toCsvRow(new String[]{
                     "", "",
-                    isNotWindows() ? "file:/my/file1.txt%20" : "file:/C:/my/file1.txt%20",
-                    isNotWindows() ? "/my/file1.txt " : "C:\\my\\file1.txt ",
+                    isNotWindows() ? "file:/my/file1.txt%20%20" : "file:/C:/my/file1.txt%20%20",
+                    isNotWindows() ? "/my/file1.txt  " : "C:\\my\\file1.txt  ",
                     "file1.txt",
                     "Signature",
                     "Done",


### PR DESCRIPTION
Should fix #1130

If you import a profile with a file with a space at the end from an OS
which allows it into DROID on Windows, the export will fail.

The file url comes in with %20 at the end which fails when calling
Path.get on Windows because spaces are not allowed at the end.

This detects if there's %20 at the end and trims it if it is running on
Windows.

The export now works for this scenario although there may be other
issues we've not found yet.
