### PR TITLE
changed to use param instead of hardcoded value 

### DIFF
--- a/droid-core-interfaces/pom.xml
+++ b/droid-core-interfaces/pom.xml
@@ -241,7 +241,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ssooidc</artifactId>
-            <version>2.31.31</version>
+            <version>${aws.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
for ssooidc, there was a hardcoded value, dependabot PR updated the variable and complained about incompatibility with this version number. Using the variable will ensure it updates to same version as well