### PR TITLE
Create 'clean' option for DROID.

### DIFF
--- a/cli-tests/test/cli-test.bats
+++ b/cli-tests/test/cli-test.bats
@@ -21,6 +21,22 @@ setup() {
   assert_output --partial 'usage: droid [options]'
 }
 
+@test "clean removes folders from droid home" {
+  $DROID_BIN --clean
+  run ls ~/.droid6
+  assert_output -p 'export_templates'
+  assert_output -p 'filter_definitions'
+  assert_output -p 'logs'
+  assert_output -p 'report_definitions'
+  refute_output -p 'container_sigs'
+  refute_output -p 'signature_files'
+  refute_output -p 'profiles'
+  refute_output -p 'profile_templates'
+  refute_output -p 'droid.properties'
+  refute_output -p 'log4j2.properties'
+  refute_output -p 'tmp'
+}
+
 @test "list the reports" {
   run $DROID_BIN -l
   assert_output -p "Report:	'Total unreadable folders'"

--- a/droid-build-tools/src/main/resources/checkstyle-main.xml
+++ b/droid-build-tools/src/main/resources/checkstyle-main.xml
@@ -155,7 +155,7 @@
     </module>
     <module name="ArrayTypeStyle"/>
     <module name="ClassDataAbstractionCoupling">
-      <property name="max" value="11"/>
+      <property name="max" value="12"/>
     </module>
     <module name="ClassFanOutComplexity">
       <property name="max" value="29"/>

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CleanCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CleanCommand.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package uk.gov.nationalarchives.droid.command.action;
 
 import org.apache.commons.io.FileUtils;

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CleanCommand.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CleanCommand.java
@@ -1,0 +1,34 @@
+package uk.gov.nationalarchives.droid.command.action;
+
+import org.apache.commons.io.FileUtils;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public class CleanCommand implements DroidCommand {
+
+    private final Path droidHome;
+    private final Stream<String> toDelete;
+
+    public CleanCommand(final Path droidHome) {
+        this.droidHome = droidHome;
+        this.toDelete = Stream.of(
+                "container_sigs",
+                "signature_files",
+                "profiles",
+                "profile_templates",
+                "droid.properties",
+                "log4j2.properties",
+                "tmp"
+        );
+    }
+
+    @Override
+    public void execute() throws CommandExecutionException {
+        toDelete.forEach(this::delete);
+    }
+
+    private void delete(final String path) {
+        FileUtils.deleteQuietly(droidHome.resolve(path).toFile());
+    }
+}

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactory.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactory.java
@@ -134,4 +134,5 @@ public interface CommandFactory {
     DroidCommand getListReportCommand();
 
 
+    DroidCommand getCleanCommand();
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactory.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactory.java
@@ -134,5 +134,8 @@ public interface CommandFactory {
     DroidCommand getListReportCommand();
 
 
+    /**
+     * @return command to clean DROID configuration folder.
+     */
     DroidCommand getCleanCommand();
 }

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandFactoryImpl.java
@@ -533,6 +533,11 @@ public class CommandFactoryImpl implements CommandFactory {
         return command;
     }
 
+    @Override
+    public DroidCommand getCleanCommand() {
+        return new CleanCommand(context.getGlobalConfig().getDroidWorkDir());
+    }
+
     private PropertiesConfiguration createProperties(String[] properties) {
         PropertiesConfiguration result = new PropertiesConfiguration();
         for (String property : properties) {

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/action/CommandLineParam.java
@@ -63,6 +63,14 @@ public enum CommandLineParam {
         }
     },
 
+    /** Clean. */
+    CLEAN("C", "clean", I18N.CLEAN_HELP) {
+        @Override
+        public DroidCommand getCommand(CommandFactory commandFactory, CommandLine cli) {
+            return commandFactory.getCleanCommand();
+        }
+    },
+
     /** Export with one row per file. */
     EXPORT_ONE_ROW_PER_FILE("e", "export-file", false, 1, I18N.EXPORT_FILE_HELP, filename()) {
         @Override
@@ -415,6 +423,7 @@ public enum CommandLineParam {
     static {
         addTopLevelCommand(HELP);
         addTopLevelCommand(VERSION);
+        addTopLevelCommand(CLEAN);
         addTopLevelCommand(EXPORT_ONE_ROW_PER_FILE);
         addTopLevelCommand(EXPORT_ONE_ROW_PER_FORMAT);
         addTopLevelCommand(REPORT);
@@ -597,6 +606,7 @@ public enum CommandLineParam {
         options.addOption(LIST_REPORTS.newOption());
         options.addOption(CONFIGURE_DEFAULT_SIGNATURE_VERSION.newOption());
         options.addOption(VERSION.newOption());
+        options.addOption(CLEAN.newOption());
         options.addOption(DEFAULT_SIGNATURE_VERSION.newOption());
         options.addOption(LIST_SIGNATURE_VERSIONS.newOption());
         return options;

--- a/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
+++ b/droid-command-line/src/main/java/uk/gov/nationalarchives/droid/command/i18n/I18N.java
@@ -218,6 +218,9 @@ public final class I18N {
     /** Export contains BOM. */
     public static final String EXPORT_WITH_BOM = "help.bom";
 
+    /** Clean command. */
+    public static final String CLEAN_HELP = "clean.help";
+
     private I18N() { }
     
     /**

--- a/droid-command-line/src/main/resources/options.properties
+++ b/droid-command-line/src/main/resources/options.properties
@@ -34,6 +34,13 @@ options.header=OPTIONS:
 invalid.options=Invalid usage: use droid -h to print the options.
 help.help=Display this help.  More help is available using the help menu in the graphical user interface.
 help.bom=Save file with BOM - Byte order mark.
+clean.help=Cleans the droid6 configuration folder. This will delete:\
+  \nBinary signature files\
+  \nContainer signature files\
+  \nProfiles\
+  \nProfile templates\
+  \nDroid properties file\
+  \nDroid log configuration
 version.help=Display the version of the DROID software.
 export.file.help=Export profiles to a CSV file with one row per profiled file.  If any filters are specified, then they will apply to the exported file.\
   \nFor example: droid -p "C:\\Results\\result1.droid" "C:\\Results\\result2.droid" -e "C:\\Exports\combinedResults.csv"\

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CleanCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CleanCommandTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 public class CleanCommandTest {
@@ -55,7 +56,7 @@ public class CleanCommandTest {
         Stream.of("droid.properties", "log4j2.properties", "not-included-file").forEach(this::createFile);
         new CleanCommand(droidHome).execute();
         Assert.assertEquals(2, Files.list(droidHome).count());
-        String[] fileNames = Files.list(droidHome).map(Path::getFileName).map(Path::toString).toArray(String[]::new);
+        String[] fileNames = Files.list(droidHome).map(Path::getFileName).map(Path::toString).sorted().toArray(String[]::new);
         Assert.assertArrayEquals(fileNames, new String[]{"not-included-directory", "not-included-file"});
     }
 

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CleanCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CleanCommandTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gov.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the The National Archives nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package uk.gov.nationalarchives.droid.command.action;
 
 import org.junit.Assert;

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CleanCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CleanCommandTest.java
@@ -1,0 +1,47 @@
+package uk.gov.nationalarchives.droid.command.action;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public class CleanCommandTest {
+
+    private Path droidHome;
+
+    @Before
+    public void setUp() throws IOException {
+        droidHome = Files.createTempDirectory("clean");
+    }
+
+    @Test
+    public void testCleanDeletesDirectories() throws CommandExecutionException, IOException {
+        Stream.of("container_sigs", "signature_files", "profiles", "profile_templates", "tmp", "not-included-directory").forEach(this::createDirectory);
+        Stream.of("droid.properties", "log4j2.properties", "not-included-file").forEach(this::createFile);
+        new CleanCommand(droidHome).execute();
+        Assert.assertEquals(2, Files.list(droidHome).count());
+        String[] fileNames = Files.list(droidHome).map(Path::getFileName).map(Path::toString).toArray(String[]::new);
+        Assert.assertArrayEquals(fileNames, new String[]{"not-included-directory", "not-included-file"});
+    }
+
+    private void createFile(String filename) {
+        try {
+            Files.createFile(droidHome.resolve(filename));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createDirectory(String directoryName) {
+        try {
+            Path directory = Files.createDirectory(droidHome.resolve(directoryName));
+            Files.createFile(directory.resolve("test"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CleanCommandTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CleanCommandTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.stream.Stream;
 
 public class CleanCommandTest {
@@ -51,7 +50,7 @@ public class CleanCommandTest {
     }
 
     @Test
-    public void testCleanDeletesDirectories() throws CommandExecutionException, IOException {
+    public void testCleanDeletesDirectoriesAndFiles() throws CommandExecutionException, IOException {
         Stream.of("container_sigs", "signature_files", "profiles", "profile_templates", "tmp", "not-included-directory").forEach(this::createDirectory);
         Stream.of("droid.properties", "log4j2.properties", "not-included-file").forEach(this::createFile);
         new CleanCommand(droidHome).execute();

--- a/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandLineParamTest.java
+++ b/droid-command-line/src/test/java/uk/gov/nationalarchives/droid/command/action/CommandLineParamTest.java
@@ -79,6 +79,14 @@ public class CommandLineParamTest {
     }
 
     @Test
+    public void testCleanHasNoArguments() {
+        Option option = CommandLineParam.CLEAN.newOption();
+        assertFalse(option.hasArg());
+        assertFalse(option.hasOptionalArg());
+        assertEquals(0, option.getArgs());
+    }
+
+    @Test
     public void testHelpHasNoArguments() {
         Option option = CommandLineParam.HELP.newOption();
         


### PR DESCRIPTION
This will clean the folders out of the ~/.droid6 directory.

This is often what is recommended when DROID misbehaves so having a
command to do this will be useful.

It will delete the following directories and files

container_sigs/
signature_files/
profiles/
profile_templates/
droid.properties
log4j2.properties
tmp/
