### PR TITLE
Fix S3 identification failure on OLE2 containers.

### DIFF
--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3WindowReader.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3WindowReader.java
@@ -64,7 +64,7 @@ public class S3WindowReader extends AbstractReader implements SoftWindowRecovery
 
     @Override
     protected Window createWindow(long windowStart) throws IOException {
-        if (windowStart >= 0) {
+        if (windowStart >= 0 && windowStart < length) {
             String key = this.s3ObjectMetadata.key().orElseThrow(() -> new RuntimeException(this.s3ObjectMetadata.key() + " not found"));
             GetObjectRequest getS3ObjectRequest = GetObjectRequest.builder()
                     .bucket(this.s3ObjectMetadata.bucket())

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3WindowReaderTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3WindowReaderTest.java
@@ -57,7 +57,7 @@ public class S3WindowReaderTest {
         WindowCache windowCache = mock(WindowCache.class);
         S3Client s3Client = mockS3Client();
         S3Uri s3Uri = S3Uri.builder().uri(URI.create("s3://bucket/key")).build();
-        S3Utils.S3ObjectMetadata s3ObjectMetadata = new S3Utils.S3ObjectMetadata("bucket", Optional.of("key"), s3Uri, 1L, 1L);
+        S3Utils.S3ObjectMetadata s3ObjectMetadata = new S3Utils.S3ObjectMetadata("bucket", Optional.of("key"), s3Uri, 4L, 1L);
         S3WindowReader s3WindowReader = new S3WindowReader(windowCache, s3ObjectMetadata, s3Client);
 
         byte[] testResponse = "test".getBytes();
@@ -80,6 +80,20 @@ public class S3WindowReaderTest {
 
         assertNull(s3WindowReader.createWindow(-1));
     }
+
+    @Test
+    public void testWindowReaderReturnsNullIfPositionGreaterOrEqualToLength() throws Exception {
+        WindowCache windowCache = mock(WindowCache.class);
+        S3Client s3Client = mockS3Client();
+        S3Uri s3Uri = S3Uri.builder().uri(URI.create("s3://bucket/key")).build();
+        S3Utils.S3ObjectMetadata s3ObjectMetadata = new S3Utils.S3ObjectMetadata("bucket", Optional.of("key"), s3Uri, 4L, 1L);
+        S3WindowReader s3WindowReader = new S3WindowReader(windowCache, s3ObjectMetadata, s3Client);
+
+        assertNotNull(s3WindowReader.createWindow(3));
+        assertNull(s3WindowReader.createWindow(4));
+        assertNull(s3WindowReader.createWindow(5));
+    }
+
 
     @Test
     public void testWindowReaderReturnsErrorOnS3Failure() throws Exception {


### PR DESCRIPTION
For OLE2 parsing we use Apache POI.

This works out the maximum length of the file by multiplying the number of sectors in the file by the size of the sectors.
Their own code comments say that for a sector size of 512 (which .doc is) they may over-estimate the size of the file by 65Kb. So DROID was
asking S3 for a byte range which was larger than the size of the file and S3 was understandably returning an error.

I don't understand the internals completely so I don't know how many .doc files are affected but it's definitely some of them.

I've added in a check so that if DROID tries to access a range that is larger than the file, it will return null. This is working with the
failing test file.
