### PR TITLE
Implement reloadWindowBytes

### DIFF
--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpWindowReader.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpWindowReader.java
@@ -58,7 +58,7 @@ public class HttpWindowReader extends AbstractReader implements SoftWindowRecove
         this.length = httpMetadata.fileSize();
     }
 
-    private HttpResponse<byte[]> responseWithRange(long rangeStart, long rangeEnd) {
+    private HttpResponse<byte[]> responseWithRange(long rangeStart, long rangeEnd) throws IOException {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(this.uri)
                 .header("Range", "bytes=" + rangeStart + "-" + rangeEnd)
@@ -67,7 +67,7 @@ public class HttpWindowReader extends AbstractReader implements SoftWindowRecove
 
         try {
             return httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
-        } catch (InterruptedException | IOException e) {
+        } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
     }
@@ -92,6 +92,7 @@ public class HttpWindowReader extends AbstractReader implements SoftWindowRecove
 
     @Override
     public byte[] reloadWindowBytes(Window window) throws IOException {
-        return new byte[0];
+        long windowStart = window.getWindowPosition();
+        return responseWithRange(windowStart, (windowStart + this.windowSize -1)).body();
     }
 }

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpWindowReaderTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/HttpWindowReaderTest.java
@@ -83,6 +83,6 @@ public class HttpWindowReaderTest {
         HttpClient httpClient = mock(HttpClient.class);
         HttpUtils.HttpMetadata httpMetadata = new HttpUtils.HttpMetadata(4L, 0L, URI.create("https://example.com"));
         when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenThrow(new IOException("Error contacting server"));
-        assertThrows(RuntimeException.class, () -> new HttpWindowReader(windowCache, httpMetadata, httpClient).getWindow(0));
+        assertThrows(IOException.class, () -> new HttpWindowReader(windowCache, httpMetadata, httpClient).getWindow(0));
     }
 }


### PR DESCRIPTION
There was a bug where DROID was returning fmt/189 for files which should
have returned fmt/1827.

The bytes that are returned from createWindow in the WindowReaders are
stored in a SoftReference inside SoftWindow. The idea being that if the
system starts to run out of memory, the byte arrays can be reclaimed by
the garbage collector.

If this happens, the byte array is null and getByteArray inside
SoftWindow calls reloadWindowBytes to repopulate the byte array.

This method was not implemented because I originally thought that it
wasn't used as it was never called when running the tests or during
manual testing. The reason it was never called is that my dev machine
has plenty of memory so the GC never had to reclaim anything.

When DROID was running in the lambda inside TDR, it only had 2Gb of
memory so for a larger file, it was running out of memory and the GC was
reclaiming the bytes. When it tried to call reloadWindowBytes to
repopulate it, it was returning an empty array and so DROID couldn't
identifiy the file.

I've implemented this method. I've tested this on TDR and it's
returning the correct PUID.
