### PR TITLE
Remove calls to HeadObject.

### DIFF
--- a/droid-api/src/main/java/uk/gov/nationalarchives/droid/internal/api/DroidAPI.java
+++ b/droid-api/src/main/java/uk/gov/nationalarchives/droid/internal/api/DroidAPI.java
@@ -361,7 +361,7 @@ public final class DroidAPI implements AutoCloseable {
             Map<HashAlgorithm, String> hashResults = generateHashResults(s3Uri, this::getS3Hash);
 
             final RequestIdentifier id = getRequestIdentifier(s3Uri.uri());
-            RequestMetaData metaData = new RequestMetaData(s3Object.size(), s3Object.lastModified().getEpochSecond(), s3Uri.uri().toString());
+            RequestMetaData metaData = new RequestMetaData(s3Object.size(), s3Object.lastModified().toEpochMilli(), s3Uri.uri().toString());
             try (final S3IdentificationRequest request = new S3IdentificationRequest(metaData, id, s3Client, DEFAULT_WINDOW_SIZE)) {
                 request.setExtension(extension);
                 request.open(s3Uri);

--- a/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITestUtils.java
+++ b/droid-api/src/test/java/uk/gov/nationalarchives/droid/internal/api/DroidAPITestUtils.java
@@ -169,16 +169,6 @@ public class DroidAPITestUtils {
                 OutputStream responseBody = exchange.getResponseBody();
                 responseBody.write(response.getBytes());
                 responseBody.close();
-            } else if (exchange.getRequestMethod().equals("HEAD")) {
-                String fullPath = exchange.getRequestURI().getPath().substring(1);
-                Path filePath = getFilePathFromUriPath(fullPath.substring(fullPath.indexOf("/")));
-                long size = Files.size(filePath);
-                exchange.getResponseHeaders().add("Content-Length", Long.toString(size));
-                exchange.getResponseHeaders().add("Last-Modified", "Mon, 03 Mar 2025 17:29:48 GMT");
-                exchange.sendResponseHeaders(200, -1);
-                OutputStream responseBody = exchange.getResponseBody();
-                responseBody.write("".getBytes());
-                responseBody.close();
             } else if (exchange.getRequestMethod().equals("GET")) {
                 String fullPath = exchange.getRequestURI().getPath().substring(1);
                 Path filePath = getFilePathFromUriPath(fullPath.substring(fullPath.indexOf("/")));

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3IdentificationRequest.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3IdentificationRequest.java
@@ -64,7 +64,7 @@ public class S3IdentificationRequest implements IdentificationRequest<S3Uri> {
         this.windowSize = windowSize;
         S3Utils s3Utils = new S3Utils(s3Client);
 
-        this.s3ObjectMetadata = s3Utils.getS3ObjectMetadata(identifier.getUri());
+        this.s3ObjectMetadata = s3Utils.getS3ObjectMetadata(identifier.getUri(), requestMetaData);
         this.s3Reader = buildWindowReader();
 
     }

--- a/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3Utils.java
+++ b/droid-core-interfaces/src/main/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3Utils.java
@@ -63,26 +63,16 @@ public class S3Utils {
 
     public record S3ObjectList(String bucket, Iterable<S3Object> contents) {}
 
-    public S3ObjectMetadata getS3ObjectMetadata(final URI uri) {
+    public S3ObjectMetadata getS3ObjectMetadata(final URI uri, RequestMetaData requestMetaData) {
 
         S3Uri s3Uri = S3Utilities.builder().region(region).build().parseUri(uri);
-        return getS3ObjectMetadata(s3Uri);
+        return getS3ObjectMetadata(s3Uri, requestMetaData);
     }
 
-    public S3ObjectMetadata getS3ObjectMetadata(final S3Uri s3Uri) {
+    public S3ObjectMetadata getS3ObjectMetadata(final S3Uri s3Uri, RequestMetaData requestMetaData) {
         String bucket = s3Uri.bucket().orElseThrow(() -> new RuntimeException(BUCKET_NOT_FOUND + s3Uri));
         Optional<String> key = s3Uri.key();
-        long contentLength = 0L;
-        long lastModified = 0L;
-        if (key.isPresent()) {
-            try {
-                HeadObjectRequest headObjectRequest = HeadObjectRequest.builder().bucket(bucket).key(key.get()).build();
-                HeadObjectResponse headObjectResponse = this.s3Client.headObject(headObjectRequest);
-                contentLength = headObjectResponse.contentLength();
-                lastModified = headObjectResponse.lastModified().getEpochSecond();
-            } catch (NoSuchKeyException ignored) {}
-        }
-        return new S3ObjectMetadata(bucket, key, s3Uri, contentLength, lastModified);
+        return new S3ObjectMetadata(bucket, key, s3Uri, requestMetaData.getSize(), requestMetaData.getTime());
     }
 
     public S3ObjectList listObjects(final URI uri) {

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3IdentificationRequestTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3IdentificationRequestTest.java
@@ -33,17 +33,12 @@ package uk.gov.nationalarchives.droid.core.interfaces.resource;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Uri;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import uk.gov.nationalarchives.droid.core.interfaces.RequestIdentifier;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 
@@ -63,7 +58,6 @@ public class S3IdentificationRequestTest {
         request.open(s3Uri);
 
         ArgumentCaptor<GetObjectRequest> getObjectRequestCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
-        verify(mockS3Client, times(1)).headObject(any(HeadObjectRequest.class));
         verify(mockS3Client, times(1)).getObject(getObjectRequestCaptor.capture());
 
         GetObjectRequest getRequestValue = getObjectRequestCaptor.getValue();
@@ -78,7 +72,7 @@ public class S3IdentificationRequestTest {
 
         request.open(s3Uri);
 
-        assertEquals(request.size(), 1);
+        assertEquals(request.size(), 2);
         assertEquals(request.getFileName(), "entry.txt");
         assertEquals(request.getExtension(), "txt");
     }
@@ -124,13 +118,6 @@ public class S3IdentificationRequestTest {
         S3Uri s3Uri = S3Uri.builder().uri(request.getIdentifier().getUri()).build();
 
         assertThrows(SdkException.class, () -> request.open(s3Uri));
-    }
-
-    @Test
-    public void testErrorIfS3HeadObjectCallsFail() {
-        S3Client mockS3Client = mock(S3Client.class);
-        when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenThrow(SdkException.class);
-        assertThrows(SdkException.class, () -> createRequest(mockS3Client));
     }
 
     private S3IdentificationRequest createRequest(S3Client mockS3Client) {

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3TestUtils.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3TestUtils.java
@@ -35,11 +35,8 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import java.io.ByteArrayInputStream;
-import java.time.Instant;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -49,10 +46,7 @@ public class S3TestUtils {
 
     static S3Client mockS3Client() {
         S3Client mockS3Client = mock(S3Client.class);
-        HeadObjectResponse response = HeadObjectResponse.builder().contentLength(1L).lastModified(Instant.ofEpochSecond(1)).build();
         GetObjectResponse getObjectResponse = GetObjectResponse.builder().build();
-        ResponseInputStream<GetObjectResponse> responseInputStream = new ResponseInputStream<>(getObjectResponse, new ByteArrayInputStream("test".getBytes()));
-        when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenReturn(response);
         when(mockS3Client.getObject(any(GetObjectRequest.class))).thenAnswer(invocation -> {
             GetObjectRequest argument = invocation.getArgument(0, GetObjectRequest.class);
             String range = argument.range();

--- a/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3UtilsTest.java
+++ b/droid-core-interfaces/src/test/java/uk/gov/nationalarchives/droid/core/interfaces/resource/S3UtilsTest.java
@@ -57,9 +57,10 @@ public class S3UtilsTest {
         S3Client s3Client = mockS3Client();
         S3Utils s3Utils = new S3Utils(s3Client, Region.EU_WEST_2);
         URI uri = URI.create("s3://bucket/key");
-        S3Utils.S3ObjectMetadata s3ObjectMetadataFromUri = s3Utils.getS3ObjectMetadata(uri);
+        RequestMetaData requestMetaData = new RequestMetaData(1L, 1L, "key");
+        S3Utils.S3ObjectMetadata s3ObjectMetadataFromUri = s3Utils.getS3ObjectMetadata(uri, requestMetaData);
         S3Uri s3Uri = S3Uri.builder().uri(uri).bucket("bucket").key("key").build();
-        S3Utils.S3ObjectMetadata s3ObjectMetadataFromS3Uri = s3Utils.getS3ObjectMetadata(s3Uri);
+        S3Utils.S3ObjectMetadata s3ObjectMetadataFromS3Uri = s3Utils.getS3ObjectMetadata(s3Uri, requestMetaData);
 
         for (S3Utils.S3ObjectMetadata s3ObjectMetadata: List.of(s3ObjectMetadataFromUri, s3ObjectMetadataFromS3Uri)) {
             assertTrue(s3ObjectMetadata.key().isPresent());

--- a/droid-core/pom.xml
+++ b/droid-core/pom.xml
@@ -116,12 +116,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-core</artifactId>
-            <version>${aws.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
             <version>${aws.version}</version>
             <scope>test</scope>

--- a/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/TestS3Client.java
+++ b/droid-core/src/test/java/uk/gov/nationalarchives/droid/core/TestS3Client.java
@@ -58,13 +58,6 @@ public class TestS3Client implements S3Client {
     }
 
     @Override
-    public HeadObjectResponse headObject(HeadObjectRequest headObjectRequest) throws NoSuchKeyException, AwsServiceException,
-            SdkClientException {
-        long size = FileUtils.sizeOf(new File(headObjectRequest.key()));
-        return HeadObjectResponse.builder().contentLength(size).lastModified(Instant.EPOCH).build();
-    }
-
-    @Override
     public void close() {}
 
     @Override

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/S3EventHandler.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/S3EventHandler.java
@@ -44,13 +44,11 @@ import uk.gov.nationalarchives.droid.core.interfaces.config.DroidGlobalConfig;
 import uk.gov.nationalarchives.droid.core.interfaces.http.S3ClientFactory;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.RequestMetaData;
 import uk.gov.nationalarchives.droid.core.interfaces.resource.S3IdentificationRequest;
-import uk.gov.nationalarchives.droid.core.interfaces.resource.S3Utils;
 import uk.gov.nationalarchives.droid.profile.AbstractProfileResource;
 import uk.gov.nationalarchives.droid.profile.throttle.SubmissionThrottle;
 
 public class S3EventHandler {
 
-    private static final int MILLIS_TO_SECONDS_FACTOR = 1000;
     private static final int DEFAULT_WINDOW_SIZE = 4 * 1024 * 1024;
 
     private AsynchDroid droidCore;
@@ -69,9 +67,7 @@ public class S3EventHandler {
 
     public void onS3Event(AbstractProfileResource resource, ResourceId parentResource) {
         S3Client s3Client = getS3Client(resource);
-        S3Utils s3Utils = new S3Utils(s3Client);
-        S3Utils.S3ObjectMetadata s3ObjectMetadata = s3Utils.getS3ObjectMetadata(resource.getUri());
-        RequestMetaData metaData = new RequestMetaData(s3ObjectMetadata.contentLength(), s3ObjectMetadata.lastModified() * MILLIS_TO_SECONDS_FACTOR, resource.getName());
+        RequestMetaData metaData = new RequestMetaData(resource.getSize(), resource.getLastModifiedDate().getTime(), resource.getName());
 
         // Prepare the identifier
         RequestIdentifier identifier = new RequestIdentifier(resource.getUri());

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/S3Walker.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/S3Walker.java
@@ -82,6 +82,7 @@ public class S3Walker {
                 progressMonitor.startJob(URI.create(objectInfo.key().replaceAll(" ", "%20")));
                 S3ProfileResource fileProfileResource = new S3ProfileResource(objectInfo.key);
                 fileProfileResource.setLastModifiedDate(objectInfo.lastModified);
+                fileProfileResource.setSize(objectInfo.size);
                 s3EventHandler.onS3Event(fileProfileResource, fileParentNode);
             }
         }
@@ -124,7 +125,7 @@ public class S3Walker {
 
             if (!dirToFileMap.containsKey(parent)) {
                 List<S3ObjectInfo> existingKeys = new ArrayList<>();
-                existingKeys.add(new S3ObjectInfo(keyUri, new Date(s3Object.lastModified().getEpochSecond())));
+                existingKeys.add(new S3ObjectInfo(keyUri, new Date(s3Object.lastModified().toEpochMilli()), s3Object.size()));
                 dirToFileMap.put(parent, existingKeys);
                 if (FORWARD_SLASH.equals(URI.create(parent).getPath())) {
                     totalCount = totalCount + 1;
@@ -134,14 +135,14 @@ public class S3Walker {
 
             } else {
                 List<S3ObjectInfo> existingKeys = dirToFileMap.get(parent);
-                existingKeys.add(new S3ObjectInfo(keyUri, new Date(s3Object.lastModified().getEpochSecond())));
+                existingKeys.add(new S3ObjectInfo(keyUri, new Date(s3Object.lastModified().toEpochMilli()), s3Object.size()));
                 dirToFileMap.put(parent, existingKeys);
                 totalCount++;
             }
         }
         return new S3Result(dirToFileMap, totalCount);
     }
-    private record S3ObjectInfo(String key, Date lastModified) {}
+    private record S3ObjectInfo(String key, Date lastModified, long size) {}
     private record S3Result(Map<String, List<S3ObjectInfo>> dirToObjectInfo, int totalCount) {
     }
 

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/S3EventHandlerTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/S3EventHandlerTest.java
@@ -37,8 +37,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import uk.gov.nationalarchives.droid.core.interfaces.AsynchDroid;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationRequest;
 import uk.gov.nationalarchives.droid.core.interfaces.ResultHandler;
@@ -51,7 +49,6 @@ import uk.gov.nationalarchives.droid.profile.throttle.SubmissionThrottle;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -143,8 +140,6 @@ public class S3EventHandlerTest {
 
         S3ClientFactory s3ClientFactory = mock(S3ClientFactory.class);
         S3Client s3Client = mock(S3Client.class);
-        HeadObjectResponse headObjectResponse = HeadObjectResponse.builder().contentLength(1L).lastModified(Instant.EPOCH).build();
-        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headObjectResponse);
         when(s3ClientFactory.getS3Client()).thenReturn(s3Client);
         return new S3EventHandler(droidCore, submissionThrottle, resultHandler, droidGlobalConfig, s3ClientFactory);
     }


### PR DESCRIPTION
We're calling headObject to get the file size and last modified but that
isn't necessary as we've already got that information from when we list the
objects. This should speed things up as we're not making unnecessary API
calls.
