### PR TITLE
Rollback jaxb-runtime until we figure out what is wrong with 4.0.6 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
+  - dependency-name: org.glassfish.jaxb:jaxb-runtime
+    versions:
+      - ">=4.0.6"
   - dependency-name: org.owasp:dependency-check-maven
     versions:
     - 6.1.0

--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -98,7 +98,7 @@
         <derby.version>10.17.1.0</derby.version>
         <cxf.version>4.1.3</cxf.version>
         <java.iso-tools.version>2.1.0</java.iso-tools.version>
-        <jaxb.version>4.0.6</jaxb.version>
+        <jaxb.version>4.0.5</jaxb.version>
         <jakarta.version>4.0.4</jakarta.version>
         <jackson.version>2.19.2</jackson.version>
         <flying-saucer.version>9.7.2</flying-saucer.version>


### PR DESCRIPTION
Ignored from dependabot as well

I think jaxb runtime between 4.0.5 to 4.0.6 has done some major changes (although only point version number is updated). I think the way it serialises for SOAP request has changed, which results in the error we are seeing when trying to check for signature updates.

For now, we roll it back to jaxb 4.0.5.