### PR TITLE
Use the pull request trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release DROID
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types:
+      - closed
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
The checks that we use to determine whether to release or not don't work unless you use the pull request trigger. This should stop a legitimate release being skipped.
