### PR TITLE
Reduce startup delay on windows

### DIFF
--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
@@ -179,8 +179,7 @@ public class ResourceSelectorDialog extends JDialog {
     
     private DefaultTreeModel getTreeModel() {
         DefaultMutableTreeNode rootNode = new DefaultMutableTreeNode(new File("File System"), true);
-        final DefaultTreeModel treeModel = new DefaultTreeModel(rootNode, true);
-        return treeModel;
+        return new DefaultTreeModel(rootNode, true);
         
     }
     
@@ -280,7 +279,6 @@ public class ResourceSelectorDialog extends JDialog {
     private String toText(List<File> files) {
         StringBuilder sb = new StringBuilder();
         for (File f : files) {
-            //sb.append(QUOTE + f.getName() + QUOTE + ' ');
             sb.append(QUOTE + fsv.getSystemDisplayName(f) + QUOTE + ' ');
         }
         return sb.toString();

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
@@ -112,7 +112,7 @@ public class ResourceSelectorDialog extends JDialog {
     private static final Class<?>[] TYPES = new Class [] {
         File.class, Long.class, Date.class, };   
     
-    private FileSystemView fsv = FileSystemView.getFileSystemView();
+    private final FileSystemView fsv = FileSystemView.getFileSystemView();
     
     private List<File> selectedFiles = new ArrayList<File>();
     
@@ -190,19 +190,17 @@ public class ResourceSelectorDialog extends JDialog {
         DefaultTreeModel treeModel = (DefaultTreeModel) tree.getModel();
         DefaultMutableTreeNode rootNode = (DefaultMutableTreeNode) treeModel.getRoot();
         File[] roots = fsv.getRoots();
-        //File[] roots = File.listRoots();
-        for (int i = 0; i < roots.length; i++) {
-            File rootFile = roots[i];
+        for (File rootFile : roots) {
             boolean rootAllowsChildren = rootFile.isDirectory();
             final DefaultMutableTreeNode newChild = new DefaultMutableTreeNode(rootFile, rootAllowsChildren);
             if (rootAllowsChildren) {
                 rootNode.add(newChild);
             }
-            
+
             File[] children = rootFile.listFiles();
             if (children != null) {
                 List<File> sortedChildren = ResourceDialogUtil.sortFiles(children);
-                
+
                 for (File child : sortedChildren) {
                     if (shouldTraverse.test(child)) {
                         final File[] listFiles = child.listFiles();


### PR DESCRIPTION
Detect the special folders which are not file system folders on Windows and do not pre load them. This will reduce the startup time but, when someone opens add resource dialog and expands any of these folders (Libraries, This PC, Network etc.), it would cause a small delay at that time.