### PR TITLE
Load the ResourceSelectorDialog asynchronously

### DIFF
--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/DroidMainFrame.java
@@ -311,8 +311,13 @@ public class DroidMainFrame extends JFrame {
         exportFileChooser = new ExportFileChooser();
         filterFileChooser = new FilterFileChooser(globalContext.getGlobalConfig().getFilterDir().toFile());
         signatureInstallDialog = new SignatureInstallDialog(this);
+
         resourceFileChooser = new ResourceSelectorDialog(this);
-        resourceFileChooser.setModal(true);
+
+        EventQueue.invokeLater(() -> {
+            resourceFileChooser.init();
+            resourceFileChooser.setModal(true);
+        });
 
         AboutDialogData data = populateAboutDialogData();
         aboutDialog = new AboutDialog(this, true, data);

--- a/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
+++ b/droid-swing-ui/src/main/java/uk/gov/nationalarchives/droid/gui/filechooser/ResourceSelectorDialog.java
@@ -122,6 +122,12 @@ public class ResourceSelectorDialog extends JDialog {
      */
     public ResourceSelectorDialog(Window parent) {
         super(parent);
+    }
+
+    /**
+     * Initialises the ResourceSelector.
+     */
+    public void init() {
         initComponents();
         initTree();
         initTable();


### PR DESCRIPTION
This takes up to 4 seconds on a Windows machine. If you load it
asynchronously, it should complete before the profile is loaded so users
should never see an incomplete resource dialog.
