### PR TITLE
fix: upgrade Log4j from 2.25.3 to 2.25.4 (CVE-2026-34480)

### DIFF
--- a/droid-parent/pom.xml
+++ b/droid-parent/pom.xml
@@ -106,7 +106,7 @@
         <jwat.version>1.1.3</jwat.version>
         <hamcrest.version>3.0</hamcrest.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <log4j2.version>2.25.3</log4j2.version>
+        <log4j2.version>2.25.4</log4j2.version>
         <checkstyle.version>10.21.2</checkstyle.version>
         <aws.version>2.41.15</aws.version>
         <junit.version>6.0.2</junit.version>


### PR DESCRIPTION
## Summary

Upgrades Log4j from `2.25.3` to `2.25.4` to address **CVE-2026-34480** (CVSS 3.1: **7.5 HIGH**).

## The vulnerability

Apache Log4j Core's `XmlLayout` fails to sanitize characters forbidden by the XML 1.0 specification. When log messages or MDC values contain these characters:

- **JRE built-in StAX parser** — forbidden characters are silently written to the output, producing malformed XML. Conforming XML parsers reject the document with a fatal error, which can cause downstream log-processing systems to silently drop affected records (integrity impact).
- **Alternative StAX implementations** (e.g. Woodstox, a transitive dependency of the Jackson XML Dataformat module that DROID uses via `jackson-dataformat-xml`) — an exception is thrown during the logging call and the log event is never delivered to its intended appender; it only reaches Log4j's internal status logger, resulting in silent data loss.

## Fix

Apache released Log4j **2.25.4**, which corrects this issue by sanitizing forbidden characters before XML output.

## Scope of change

Minimal — a single property bump in `droid-parent/pom.xml`:

```diff
- <log4j2.version>2.25.3</log4j2.version>
+ <log4j2.version>2.25.4</log4j2.version>
```

All Log4j module references (`log4j-api`, `log4j-core`, `log4j-slf4j2-impl`) use ${log4j2.version}, so the change propagates correctly to all sub-modules.

## References
- https://nvd.nist.gov/vuln/detail/CVE-2026-34480
- https://logging.apache.org/log4j/2.x/manual/layouts.html#XmlLayout
- https://github.com/apache/logging-log4j2/pull/4077
- https://lists.apache.org/thread/5x0hcnng0chhghp6jgjdp3qmbbhfjzhb