### PR TITLE
Log URI in ItemWriterImplTest

### DIFF
--- a/droid-results/pom.xml
+++ b/droid-results/pom.xml
@@ -60,11 +60,24 @@
 							<name>derby.stream.error.file</name>
 							<value>${basedir}/target/derby.log</value>
 						</property>
+						<property>
+							<name>droidUserDir</name>
+							<value>${project.build.directory}/droid-runtime</value>
+						</property>
+						<property>
+							<name>droidTempDir</name>
+							<value>${project.build.directory}/droid-runtime</value>
+						</property>
 					</systemProperties>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit4</artifactId>
+						<version>3.5.6</version>
+					</dependency>
+				</dependencies>
 			</plugin>
-
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
@@ -385,11 +398,6 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
-			<version>${aws.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>sdk-core</artifactId>
 			<version>${aws.version}</version>
 		</dependency>
 		<dependency>

--- a/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ItemWriterImpl.java
+++ b/droid-results/src/main/java/uk/gov/nationalarchives/droid/profile/ItemWriterImpl.java
@@ -184,6 +184,7 @@ public class ItemWriterImpl implements ItemWriter<ProfileResourceNode> {
             this.outputJson = new FormattedDataWriter.OutputJson(outputWriter);
         }
         final CsvWriterSettings csvWriterSettings = new CsvWriterSettings();
+        csvWriterSettings.setIgnoreTrailingWhitespaces(false);
         csvWriterSettings.setQuoteAllFields(quoteAllFields);
         CsvFormat format = new CsvFormat();
         // following Unix convention about line separators as previously

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
@@ -37,9 +37,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationMethod;
@@ -59,7 +57,11 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +86,8 @@ import static org.mockito.Mockito.when;
  */
 public class ItemWriterImplTest {
 
-    private static final DateTime testDateTime = new DateTime(12345678L);
+//    private static final DateTime testDateTime = new DateTime(12345678L, DateTimeZone.getDefault());
+    private static final long TEST_LAST_MODIFIED_MILLIS = 12345678L;
     private static final String LINE_SEPARATOR = "\n";
     private ItemWriterImpl itemWriter;
     private DroidGlobalConfig config;
@@ -105,8 +108,9 @@ public class ItemWriterImplTest {
 
         config = mock(DroidGlobalConfig.class);
         itemWriter.setConfig(config);
-        DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss");
-        testDateTimeString = dtf.print(testDateTime);
+        testDateTimeString = Instant.ofEpochMilli(TEST_LAST_MODIFIED_MILLIS)
+                .atZone(ZoneId.systemDefault())
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
     }
 
     private static String toCsvRow(final String[] values) {
@@ -1572,7 +1576,7 @@ public class ItemWriterImplTest {
         NodeMetaData metaData = new NodeMetaData();
         metaData.setExtension("foo");
         metaData.setIdentificationMethod(IdentificationMethod.BINARY_SIGNATURE);
-        metaData.setLastModified(testDateTime.getMillis());
+        metaData.setLastModified(TEST_LAST_MODIFIED_MILLIS);
         metaData.setName("file" + i + ".txt");
         metaData.setNodeStatus(NodeStatus.DONE);
         metaData.setResourceType(ResourceType.FILE);

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationMethod;
@@ -61,7 +60,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +84,6 @@ import static org.mockito.Mockito.when;
  */
 public class ItemWriterImplTest {
 
-//    private static final DateTime testDateTime = new DateTime(12345678L, DateTimeZone.getDefault());
     private static final long TEST_LAST_MODIFIED_MILLIS = 12345678L;
     private static final String LINE_SEPARATOR = "\n";
     private ItemWriterImpl itemWriter;
@@ -188,8 +185,8 @@ public class ItemWriterImplTest {
 
             final String expectedEntry = toCsvRow(new String[]{
                     "", "",
-                    isNotWindows() ? "file:/my/file1.txt%20%20" : "file:/C:/my/file1.txt%20%20",
-                    isNotWindows() ? "/my/file1.txt  " : "C:\\my\\file1.txt  ",
+                    isNotWindows() ? "file:/my/file1.txt%20%20" : "file:/C:/my/file1.txt",
+                    isNotWindows() ? "/my/file1.txt  " : "C:\\my\\file1.txt",
                     "file1.txt",
                     "Signature",
                     "Done",

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
@@ -178,7 +178,6 @@ public class ItemWriterImplTest {
             ProfileResourceNode node = buildProfileResourceNode(1, 1001L, f.toURI());
             node.addFormatIdentification(id);
             nodes.add(node);
-            System.out.println(" **** THE URI is " + node.getUri().toString());
             itemWriter.setOptions(ExportOptions.ONE_ROW_PER_FORMAT);
             itemWriter.open(writer);
             itemWriter.write(nodes);

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationMethod;
@@ -170,12 +171,14 @@ public class ItemWriterImplTest {
 
     @Test
     public void should_write_node_file_name_with_space_at_the_end() throws IOException {
+        //Windows cannot have a file with trailing spaces, so this test is not applicable for Windows.
+        Assume.assumeFalse("Test not applicable on Windows", SystemUtils.IS_OS_WINDOWS);
         when(config.getBooleanProperty(DroidGlobalProperty.CSV_EXPORT_ROW_PER_FORMAT)).thenReturn(false);
 
         try(final Writer writer = new StringWriter()) {
             List<ProfileResourceNode> nodes = new ArrayList<>();
             Format id = buildFormat(1);
-            File f = isNotWindows() ? new File("/my/file1.txt  ") : new File("C:/my/file1.txt  ");
+            File f = new File("/my/file1.txt  ");
             ProfileResourceNode node = buildProfileResourceNode(1, 1001L, f.toURI());
             node.addFormatIdentification(id);
             nodes.add(node);
@@ -185,8 +188,8 @@ public class ItemWriterImplTest {
 
             final String expectedEntry = toCsvRow(new String[]{
                     "", "",
-                    isNotWindows() ? "file:/my/file1.txt%20%20" : "file:/C:/my/file1.txt",
-                    isNotWindows() ? "/my/file1.txt  " : "C:\\my\\file1.txt",
+                    "file:/my/file1.txt%20%20",
+                    "/my/file1.txt  ",
                     "file1.txt",
                     "Signature",
                     "Done",

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/profile/ItemWriterImplTest.java
@@ -178,6 +178,7 @@ public class ItemWriterImplTest {
             ProfileResourceNode node = buildProfileResourceNode(1, 1001L, f.toURI());
             node.addFormatIdentification(id);
             nodes.add(node);
+            System.out.println(" **** THE URI is " + node.getUri().toString());
             itemWriter.setOptions(ExportOptions.ONE_ROW_PER_FORMAT);
             itemWriter.open(writer);
             itemWriter.write(nodes);

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/FileWalkerPersistenceTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/FileWalkerPersistenceTest.java
@@ -40,6 +40,10 @@ import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -47,9 +51,6 @@ import jakarta.xml.bind.JAXBException;
 
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -104,14 +105,14 @@ public class FileWalkerPersistenceTest {
         state.setCurrentResource(new DirectoryProfileResource(root, true));
         
         profileWalkerDao.save(state);
-        
-        DateTime testDateTime = new DateTime(0L);
-        DateTimeFormatter formatter = ISODateTimeFormat.dateTimeNoMillis();
+
+        ZonedDateTime testDateTime = Instant.ofEpochMilli(0L).atZone(ZoneId.systemDefault());
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
         String control = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
             + "<ProfileWalk Status=\"NOT_STARTED\">\n"
             + "    <Dir Recursive=\"true\">\n"
             + "        <Size>-1</Size>\n"
-            + "        <LastModifiedDate>" + formatter.print(testDateTime) + "</LastModifiedDate>\n"
+            + "        <LastModifiedDate>" + formatter.format(testDateTime) + "</LastModifiedDate>\n"
             + "        <Extension></Extension>\n"
             + "        <Name>root</Name>\n"
             + "        <Uri>" + root.toUri() + "</Uri>\n"

--- a/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecWalkerImplTest.java
+++ b/droid-results/src/test/java/uk/gov/nationalarchives/droid/submitter/ProfileSpecWalkerImplTest.java
@@ -36,6 +36,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -182,7 +183,11 @@ public class ProfileSpecWalkerImplTest {
 
         for (AbstractProfileResource resource : s3Resources) {
             String key = resource.getName().startsWith("/") ? resource.getName().substring(1) : resource.getName();
-            S3Object s3Object = S3Object.builder().key(key).build();
+            S3Object s3Object = S3Object.builder()
+                    .key(key)
+                    .lastModified(Instant.parse("2024-06-06T00:00:00Z"))
+                    .size(1L)
+                    .build();
             ArgumentMatcher<ListObjectsV2Request> requestArgumentMatcher = argument ->
                     argument != null && resource.getName().equals(argument.prefix());
             ListObjectsV2Response response = ListObjectsV2Response.builder().contents(List.of(s3Object)).build();

--- a/droid-results/src/test/resources/jpa-test.properties
+++ b/droid-results/src/test/resources/jpa-test.properties
@@ -65,6 +65,7 @@ profileHome=profileHome
 generateHash=false
 hashAlgorithm=md5
 maxBytesToScan=-1
+exportOutputOptions=CSV_OUTPUT
 
 # BNO 27-Oct-2015. The JpaPlanetsXMLDaoTest was failing with
 # Invalid bean definition with name 'submissionGateway' defined in URL


### PR DESCRIPTION
This PR got modified to do 
- Use Junit4 provider in droid-results 
- Avoid using joda-date was merged from elsewhere to fix the one hour out failures on CI
- Trailing space test updated 
- Trailing space implementation also updated to set `ignoretrailingspaces` in CSVWriterSettings to be false

The PR has changed shape, but, hopefully this will fix all of the random failure situationss