### PR TITLE
Excluded droid-binary from deployment

### DIFF
--- a/droid-binary/pom.xml
+++ b/droid-binary/pom.xml
@@ -22,6 +22,20 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
                 <version>1.13.0</version>


### PR DESCRIPTION
* This should work
* I've tested locally by creating an alternate profile and deploying to alternate local folder
* release plugin calls deploy, so this should work, but there is still a slim chance that `release:prepare` and `release:perform` may throw some unknowns  